### PR TITLE
Expose a rewrap function

### DIFF
--- a/src/wrappers.js
+++ b/src/wrappers.js
@@ -178,7 +178,7 @@
       wrapperTable.set(node, wrapper);
     }
     return wrapper;
-  };
+  }
 
   /**
    * Unwraps a wrapper and returns the node it is wrapping.
@@ -190,20 +190,32 @@
       return null;
     assert(wrapper instanceof WrapperNode);
     return wrapper.node;
-  };
+  }
+
+  /**
+   * Overrides the current wrapper (if any) for node.
+   * @param {Node} node
+   * @param {WrapperNode=} wrapper If left out the wrapper will be created as
+   *     needed next time someone wraps the node.
+   */
+  function rewrap(node, wrapper) {
+    if (wrapper === null)
+      return;
+    assert(node instanceof Node);
+    assert(wrapper === undefined || wrapper instanceof WrapperNode);
+    wrapperTable.set(node, wrapper);
+  }
 
   // Used all over... we should move to a generic util file.
   exports.mixin = mixin;
 
   exports.wrap = wrap;
   exports.unwrap = unwrap;
+  exports.rewrap = rewrap;
   exports.wrappers = {
     register: register,
     registerHTMLElement: registerHTMLElement,
     registerObject: registerObject
   };
-
-  // Needed to override the wrapper in ShadowRoot.
-  exports.wrapperTable = wrapperTable;
 
 })(this);

--- a/src/wrappers/ShadowRoot.js
+++ b/src/wrappers/ShadowRoot.js
@@ -11,7 +11,7 @@
 
     // createDocumentFragment associates the node with a WrapperDocumentFragment
     // instance. Override that.
-    wrapperTable.set(node, this);
+    rewrap(node, this);
 
     var oldShadowRoot = hostWrapper.__shadowRoot__;
     this.__nextOlderShadowTree__ = oldShadowRoot;

--- a/test/custom-element.js
+++ b/test/custom-element.js
@@ -15,7 +15,7 @@ suite('Custom Element', function() {
     var div = document.createElement('div');
     // strip wrapper (TODO(sjmiles): should we make api for this?)
     div = unwrap(div);
-    wrapperTable.set(div, undefined);
+    rewrap(div);
     // implement custom API
     if (Object.__proto__) {
       // for browsers that support __proto__


### PR DESCRIPTION
``` js
rewrap(node, wrapper = undefined)
```

This allows other polyfills to reset the wrapper of an existing node either to
a new wrapper (WrapperShadowRoot does this) or to undefined (custom elements
need this).
