### PR TITLE
Implement custom event dispatching that walks the adjusted ancestor tree

### DIFF
--- a/src/wrappers/Event.js
+++ b/src/wrappers/Event.js
@@ -17,8 +17,12 @@
     this.node = original;
   }
 
-  addWrapGetter(WrapperEvent, 'target');
-  addWrapGetter(WrapperEvent, 'currentTarget');
+  WrapperEvent.prototype = {
+    // These are overridden in EventTarget.js
+    get target() {},
+    get currentTarget() {},
+    get eventPhase() {}
+  };
 
   wrappers.register(Event, WrapperEvent, document.createEvent('Event'));
 

--- a/test/events.js
+++ b/test/events.js
@@ -120,4 +120,77 @@ suite('Events', function() {
                      [b, a, content, p, sr, shadow, q, sr2, div]);
   });
 
+  test('click with shadow', function() {
+    function addListener(target, currentTarget) {
+      calls += 2;
+      currentTarget.addEventListener('click', function f(e) {
+        calls--;
+        assert.equal(e.eventPhase, Event.CAPTURING_PHASE);
+        assert.equal(e.target, target);
+        assert.equal(e.currentTarget, currentTarget);
+        assert.equal(e.currentTarget, this);
+        currentTarget.removeEventListener('click', f, true);
+      }, true);
+      currentTarget.addEventListener('click', function f(e) {
+        calls--;
+        assert.equal(e.eventPhase, Event.BUBBLING_PHASE);
+        assert.equal(e.target, target);
+        assert.equal(e.currentTarget, currentTarget);
+        assert.equal(e.currentTarget, this);
+        currentTarget.removeEventListener('click', f, false);
+      }, false);
+    }
+
+    var div = document.createElement('div');
+    div.innerHTML = '<a><b></b></a>';
+    var a = div.firstChild;
+    var b = a.firstChild;
+    var sr = div.createShadowRoot();
+    sr.innerHTML = '<p><content></content></p>';
+    var p = sr.firstChild;
+    var content = p.firstChild;
+
+    // trigger recalc
+    div.offsetWidth;
+
+    var calls = 0;
+
+    addListener(b, div);
+    addListener(b, sr);
+    addListener(b, p);
+    addListener(b, content);
+    addListener(b, a);
+    addListener(b, b);
+    b.click();
+    assert.equal(calls, 0);
+
+    addListener(div, div);
+    addListener(content, sr);
+    addListener(content, p);
+    addListener(content, content);
+    content.click();
+    assert.equal(calls, 0);
+
+    var sr2 = div.createShadowRoot();
+    sr2.innerHTML = '<q><shadow></shadow></q>';
+    var q = sr2.firstChild;
+    var shadow = q.firstChild;
+
+    // trigger recalc
+    div.offsetWidth;
+
+    addListener(b, div);
+    addListener(b, sr2);
+    addListener(b, q);
+    addListener(b, shadow);
+    addListener(b, sr);
+    addListener(b, p);
+    addListener(b, content);
+    addListener(b, a);
+    addListener(b, b);
+
+    b.click();
+    assert.equal(calls, 0);
+  });
+
 });


### PR DESCRIPTION
This works by listening to the underlying event using capturing. When the event
occurs we gather the adjusted ancestors and manually dispatch along that path.

This does not yet handle stopPropagation nor stopImmediatePropagation.
