### PR TITLE
Override builtin native constructors.

### DIFF
--- a/shadowdom.js
+++ b/shadowdom.js
@@ -30,7 +30,8 @@
     'wrappers/generic.js',
     'wrappers/ShadowRoot.js',
     'ShadowRenderer.js',
-    'wrappers/Document.js'
+    'wrappers/Document.js',
+    'wrappers/override-constructors.js'
   ].forEach(function(src) {
     document.write('<script src="' + base + src + '"></script>');
   });

--- a/src/wrappers/CharacterData.js
+++ b/src/wrappers/CharacterData.js
@@ -8,11 +8,11 @@
   var ChildNodeInterface = scope.ChildNodeInterface;
   var WrapperNode = scope.WrapperNode;
   var mixin = scope.mixin;
-  var wrappers = scope.wrappers;
+  var registerWrapper = scope.registerWrapper;
 
-  function WrapperCharacterData(node) {
+  var WrapperCharacterData = function CharacterData(node) {
     WrapperNode.call(this, node);
-  }
+  };
   WrapperCharacterData.prototype = Object.create(WrapperNode.prototype);
   mixin(WrapperCharacterData.prototype, {
     get textContent() {
@@ -25,8 +25,8 @@
 
   mixin(WrapperCharacterData.prototype, ChildNodeInterface);
 
-  wrappers.register(CharacterData, WrapperCharacterData,
-                    document.createTextNode(''));
+  registerWrapper(CharacterData, WrapperCharacterData,
+                  document.createTextNode(''));
 
   scope.WrapperCharacterData = WrapperCharacterData;
 })(this.ShadowDOMPolyfill);

--- a/src/wrappers/Document.js
+++ b/src/wrappers/Document.js
@@ -12,13 +12,13 @@
   var unwrap = scope.unwrap;
   var wrap = scope.wrap;
   var wrapNodeList = scope.wrapNodeList;
-  var wrappers = scope.wrappers;
+  var registerWrapper = scope.registerWrapper;
 
   var implementationTable = new SideTable();
 
-  function WrapperDocument(node) {
+  var WrapperDocument = function Document(node) {
     WrapperNode.call(this, node);
-  }
+  };
   WrapperDocument.prototype = Object.create(WrapperNode.prototype);
 
   addWrapGetter(WrapperDocument, 'documentElement');
@@ -42,13 +42,13 @@
     }
   });
 
-  wrappers.register(Document, WrapperDocument,
+  registerWrapper(Document, WrapperDocument,
       document.implementation.createHTMLDocument(''));
 
   // Both WebKit and Gecko uses HTMLDocument for document. HTML5/DOM only has
   // one Document interface and IE implements the standard correctly.
   if (typeof HTMLDocument !== 'undefined')
-    wrappers.register(HTMLDocument, WrapperDocument);
+    registerWrapper(HTMLDocument, WrapperDocument);
 
   function wrapMethod(name) {
     var proto = Object.getPrototypeOf(document);
@@ -122,9 +122,9 @@
     };
   }
 
-  function WrapperDOMImplementation(node) {
+  var WrapperDOMImplementation = function DOMImplementation(node) {
     this.impl = node;
-  }
+  };
 
   wrapImplMethod(WrapperDOMImplementation, 'createDocumentType');
   wrapImplMethod(WrapperDOMImplementation, 'createDocument');

--- a/src/wrappers/Element.js
+++ b/src/wrappers/Element.js
@@ -11,13 +11,14 @@
   var WrapperNode = scope.WrapperNode;
   var addWrapNodeListMethod = scope.addWrapNodeListMethod;
   var mixin = scope.mixin;
+  var registerWrapper = scope.registerWrapper;
   var wrappers = scope.wrappers;
 
   var shadowRootTable = new SideTable();
 
-  function WrapperElement(node) {
+  var WrapperElement = function Element(node) {
     WrapperNode.call(this, node);
-  }
+  };
   WrapperElement.prototype = Object.create(WrapperNode.prototype);
   mixin(WrapperElement.prototype, {
     createShadowRoot: function() {
@@ -56,7 +57,7 @@
     addWrapNodeListMethod(WrapperElement, name);
   });
 
-  wrappers.register(Element, WrapperElement);
+  registerWrapper(Element, WrapperElement);
 
   scope.WrapperElement = WrapperElement;
 })(this.ShadowDOMPolyfill);

--- a/src/wrappers/EventTarget.js
+++ b/src/wrappers/EventTarget.js
@@ -8,6 +8,7 @@
   var mixin = scope.mixin;
   var unwrap = scope.unwrap;
   var wrap = scope.wrap;
+  var registerWrapper = scope.registerWrapper;
   var wrappers = scope.wrappers;
 
   var wrappedFuns = new SideTable();
@@ -299,12 +300,12 @@
    * @param {!Node} original The original DOM node, aka, the visual DOM node.
    * @constructor
    */
-  function WrapperEvent(original) {
+  var WrapperEvent = function Event(original) {
     /**
      * @type {!Event}
      */
     this.impl = original;
-  }
+  };
 
   WrapperEvent.prototype = {
     get target() {
@@ -325,30 +326,29 @@
     }
   };
 
-  wrappers.register(Event, WrapperEvent, document.createEvent('Event'));
+  registerWrapper(Event, WrapperEvent, document.createEvent('Event'));
 
-  function WrapperUIEvent(original) {
+  var WrapperUIEvent = function UIEvent(original) {
     WrapperEvent.call(this, original);
-  }
+  };
   WrapperUIEvent.prototype = Object.create(WrapperEvent.prototype);
-  wrappers.register(UIEvent, WrapperUIEvent,
-                    document.createEvent('UIEvent'));
+  registerWrapper(UIEvent, WrapperUIEvent, document.createEvent('UIEvent'));
 
-  function WrapperMouseEvent(original) {
-    WrapperEvent.call(this, original);
-  }
+  var WrapperMouseEvent = function MouseEvent(original) {
+    WrapperUIEvent.call(this, original);
+  };
   WrapperMouseEvent.prototype = Object.create(WrapperUIEvent.prototype);
   mixin(WrapperMouseEvent.prototype, {
     get relatedTarget() {
       return relatedTargetTable.get(this);
     }
   });
-  wrappers.register(MouseEvent, WrapperMouseEvent,
-                    document.createEvent('MouseEvent'));
+  registerWrapper(MouseEvent, WrapperMouseEvent,
+                  document.createEvent('MouseEvent'));
 
-  function WrapperFocusEvent(original) {
-    WrapperEvent.call(this, original);
-  }
+  var WrapperFocusEvent = function FocusEvent(original) {
+    WrapperUIEvent.call(this, original);
+  };
   WrapperFocusEvent.prototype = Object.create(WrapperUIEvent.prototype);
   mixin(WrapperFocusEvent.prototype, {
     get relatedTarget() {
@@ -356,8 +356,8 @@
     }
   });
   if (typeof FocusEvent !== 'undefined') {
-    wrappers.register(FocusEvent, WrapperFocusEvent,
-                      document.createEvent('FocusEvent'));
+    registerWrapper(FocusEvent, WrapperFocusEvent,
+                    document.createEvent('FocusEvent'));
   }
 
   function isValidListener(fun) {
@@ -371,12 +371,12 @@
    * @param {!Node} original The original DOM node, aka, the visual DOM node.
    * @constructor
    */
-  function WrapperEventTarget(original) {
+  var WrapperEventTarget = function EventTarget(original) {
     /**
      * @type {!Node}
      */
     this.impl = original;
-  }
+  };
 
   var originalAddEventListener = Node.prototype.addEventListener;
   var originalRemoveEventListener = Node.prototype.removeEventListener;
@@ -439,7 +439,7 @@
   };
 
   if (typeof EventTarget !== 'undefined')
-    wrappers.register(EventTarget, WrapperEventTarget);
+    registerWrapper(EventTarget, WrapperEventTarget);
 
   scope.WrapperEvent = WrapperEvent;
   scope.WrapperEventTarget = WrapperEventTarget;

--- a/src/wrappers/HTMLContentElement.js
+++ b/src/wrappers/HTMLContentElement.js
@@ -7,11 +7,11 @@
 
   var WrapperHTMLElement = scope.WrapperHTMLElement;
   var mixin = scope.mixin;
-  var wrappers = scope.wrappers;
+  var registerWrapper = scope.registerWrapper;
 
-  function WrapperHTMLContentElement(node) {
+  var WrapperHTMLContentElement = function HTMLContentElement(node) {
     WrapperHTMLElement.call(this, node);
-  }
+  };
   WrapperHTMLContentElement.prototype = Object.create(WrapperHTMLElement.prototype);
   mixin(WrapperHTMLContentElement.prototype, {
     get select() {
@@ -28,7 +28,7 @@
   });
 
   if (typeof HTMLContentElement !== 'undefined')
-    wrappers.register(HTMLContentElement, WrapperHTMLContentElement);
+    registerWrapper(HTMLContentElement, WrapperHTMLContentElement);
 
   scope.WrapperHTMLContentElement = WrapperHTMLContentElement;
 })(this.ShadowDOMPolyfill);

--- a/src/wrappers/HTMLElement.js
+++ b/src/wrappers/HTMLElement.js
@@ -9,7 +9,7 @@
   var mixin = scope.mixin;
   var unwrap = scope.unwrap;
   var wrap = scope.wrap;
-  var wrappers = scope.wrappers;
+  var registerWrapper = scope.registerWrapper;
 
   /////////////////////////////////////////////////////////////////////////////
   // innerHTML and outerHTML
@@ -96,9 +96,9 @@
     }
   }
 
-  function WrapperHTMLElement(node) {
+  var WrapperHTMLElement = function HTMLElement(node) {
     WrapperElement.call(this, node);
-  }
+  };
   WrapperHTMLElement.prototype = Object.create(WrapperElement.prototype);
   mixin(WrapperHTMLElement.prototype, {
     get innerHTML() {
@@ -168,8 +168,8 @@
   ].forEach(methodRequiresRendering);
 
   // HTMLElement is abstract so we use a subclass that has no members.
-  wrappers.register(HTMLElement, WrapperHTMLElement,
-                    document.createElement('span'));
+  registerWrapper(HTMLElement, WrapperHTMLElement,
+                  document.createElement('span'));
 
   scope.WrapperHTMLElement = WrapperHTMLElement;
 

--- a/src/wrappers/HTMLShadowElement.js
+++ b/src/wrappers/HTMLShadowElement.js
@@ -7,12 +7,12 @@
 
   var WrapperHTMLElement = scope.WrapperHTMLElement;
   var mixin = scope.mixin;
-  var wrappers = scope.wrappers;
+  var registerWrapper = scope.registerWrapper;
 
-  function WrapperHTMLShadowElement(node) {
+  var WrapperHTMLShadowElement = function HTMLShadowElement(node) {
     WrapperHTMLElement.call(this, node);
     this.olderShadowRoot_ = null;
-  }
+  };
   WrapperHTMLShadowElement.prototype = Object.create(WrapperHTMLElement.prototype);
   mixin(WrapperHTMLShadowElement.prototype, {
     get olderShadowRoot() {
@@ -22,7 +22,7 @@
   });
 
   if (typeof HTMLShadowElement !== 'undefined')
-    wrappers.register(HTMLShadowElement, WrapperHTMLShadowElement);
+    registerWrapper(HTMLShadowElement, WrapperHTMLShadowElement);
 
   scope.WrapperHTMLShadowElement = WrapperHTMLShadowElement;
 })(this.ShadowDOMPolyfill);

--- a/src/wrappers/HTMLTemplateElement.js
+++ b/src/wrappers/HTMLTemplateElement.js
@@ -10,7 +10,7 @@
   var mixin = scope.mixin;
   var setInnerHTML = scope.setInnerHTML;
   var wrap = scope.wrap;
-  var wrappers = scope.wrappers;
+  var registerWrapper = scope.registerWrapper;
 
   var hasNative = typeof HTMLTemplateElement !== 'undefined';
   var contentTable = new SideTable();
@@ -44,9 +44,9 @@
     return df;
   }
 
-  function WrapperHTMLTemplateElement(node) {
+  var WrapperHTMLTemplateElement = function HTMLTemplateElement(node) {
     WrapperHTMLElement.call(this, node);
-  }
+  };
   WrapperHTMLTemplateElement.prototype = Object.create(WrapperHTMLElement.prototype);
 
   mixin(WrapperHTMLTemplateElement.prototype, {
@@ -78,7 +78,7 @@
   });
 
   if (hasNative)
-    wrappers.register(HTMLTemplateElement, WrapperHTMLTemplateElement);
+    registerWrapper(HTMLTemplateElement, WrapperHTMLTemplateElement);
 
   scope.WrapperHTMLTemplateElement = WrapperHTMLTemplateElement;
 })(this.ShadowDOMPolyfill);

--- a/src/wrappers/HTMLUnknownElement.js
+++ b/src/wrappers/HTMLUnknownElement.js
@@ -10,9 +10,9 @@
   var WrapperHTMLShadowElement = scope.WrapperHTMLShadowElement;
   var WrapperHTMLTemplateElement = scope.WrapperHTMLTemplateElement;
   var mixin = scope.mixin;
-  var wrappers = scope.wrappers;
+  var registerWrapper = scope.registerWrapper;
 
-  function WrapperHTMLUnknownElement(node) {
+  var WrapperHTMLUnknownElement = function HTMLUnknownElement(node) {
     switch (node.localName) {
       case 'content':
         return new WrapperHTMLContentElement(node);
@@ -22,8 +22,8 @@
         return new WrapperHTMLTemplateElement(node);
     }
     WrapperHTMLElement.call(this, node);
-  }
+  };
   WrapperHTMLUnknownElement.prototype = Object.create(WrapperHTMLElement.prototype);
-  wrappers.register(HTMLUnknownElement, WrapperHTMLUnknownElement);
+  registerWrapper(HTMLUnknownElement, WrapperHTMLUnknownElement);
   scope.WrapperHTMLUnknownElement = WrapperHTMLUnknownElement;
 })(this.ShadowDOMPolyfill);

--- a/src/wrappers/Node.js
+++ b/src/wrappers/Node.js
@@ -10,6 +10,7 @@
   var addWrapGetter = scope.addWrapGetter;
   var assert = scope.assert;
   var mixin = scope.mixin;
+  var registerWrapper = scope.registerWrapper;
   var unwrap = scope.unwrap;
   var wrap = scope.wrap;
   var wrappers = scope.wrappers;
@@ -81,14 +82,16 @@
     wrapper.firstChild_ = wrapper.lastChild_ = null;
   }
 
+  var originalNode = Node;
+
   /**
    * This represents a logical DOM node.
    * @param {!Node} original The original DOM node, aka, the visual DOM node.
    * @constructor
    * @extends {WrapperEventTarget}
    */
-  function WrapperNode(original) {
-    assert(original instanceof Node);
+  var WrapperNode = function Node(original) {
+    assert(original instanceof originalNode);
 
     WrapperEventTarget.call(this, original);
 
@@ -125,7 +128,7 @@
      * @private
      */
     this.previousSibling_ = undefined;
-  }
+  };
 
   WrapperNode.prototype = Object.create(WrapperEventTarget.prototype);
   mixin(WrapperNode.prototype, {
@@ -349,7 +352,7 @@
   // We use a DocumentFragment as a base and then delete the properties of
   // DocumentFragment.prototype from the WrapperNode. Since delete makes objects
   // slow in some JS engines we recreate the prototype object.
-  wrappers.register(Node, WrapperNode, document.createDocumentFragment());
+  registerWrapper(Node, WrapperNode, document.createDocumentFragment());
   delete WrapperNode.prototype.querySelector;
   delete WrapperNode.prototype.querySelectorAll;
   WrapperNode.prototype =

--- a/src/wrappers/NodeList.js
+++ b/src/wrappers/NodeList.js
@@ -11,10 +11,10 @@
     Object.defineProperty(obj, prop, {enumerable: false});
   }
 
-  function WrapperNodeList() {
+  var WrapperNodeList = function NodeList() {
     this.length = 0;
     nonEnum(this, 'length');
-  }
+  };
   WrapperNodeList.prototype = {
     item: function(index) {
       return this[index];

--- a/src/wrappers/ShadowRoot.js
+++ b/src/wrappers/ShadowRoot.js
@@ -14,7 +14,7 @@
 
   var shadowHostTable = new SideTable();
 
-  function WrapperShadowRoot(hostWrapper) {
+  var WrapperShadowRoot = function ShadowRoot(hostWrapper) {
     var node = unwrap(hostWrapper.impl.ownerDocument.createDocumentFragment());
     WrapperDocumentFragment.call(this, node);
 
@@ -29,7 +29,7 @@
 
     // TODO: are we invalidating on both sides?
     hostWrapper.invalidateShadowRenderer();
-  }
+  };
   WrapperShadowRoot.prototype = Object.create(WrapperDocumentFragment.prototype);
   mixin(WrapperShadowRoot.prototype, {
     get innerHTML() {

--- a/src/wrappers/generic.js
+++ b/src/wrappers/generic.js
@@ -8,15 +8,15 @@
   var ParentNodeInterface = scope.ParentNodeInterface;
   var SelectorsInterface = scope.SelectorsInterface;
   var mixin = scope.mixin;
-  var wrappers = scope.wrappers;
+  var registerObject = scope.registerObject;
 
   var WrapperDocumentFragment =
-      wrappers.registerObject(document.createDocumentFragment());
+      registerObject(document.createDocumentFragment());
   mixin(WrapperDocumentFragment.prototype, ParentNodeInterface);
   mixin(WrapperDocumentFragment.prototype, SelectorsInterface);
 
-  wrappers.registerObject(document.createTextNode(''));
-  wrappers.registerObject(document.createComment(''));
+  registerObject(document.createTextNode(''));
+  registerObject(document.createComment(''));
 
   scope.WrapperDocumentFragment = WrapperDocumentFragment;
 

--- a/src/wrappers/override-constructors.js
+++ b/src/wrappers/override-constructors.js
@@ -1,0 +1,25 @@
+// Copyright 2013 The Toolkitchen Authors. All rights reserved.
+// Use of this source code is goverened by a BSD-style
+// license that can be found in the LICENSE file.
+
+(function(scope) {
+  'use strict';
+
+  var isWrapperFor = scope.isWrapperFor;
+
+  Object.getOwnPropertyNames(scope).forEach(function(name) {
+    if (/^Wrapper/.test(name)) {
+      var wrapperConstructor = scope[name];
+      var nativeConstructorName = name.slice(7);
+      var nativeConstructor = window[nativeConstructorName];
+      if (nativeConstructor &&
+          isWrapperFor(wrapperConstructor, nativeConstructor)) {
+        window[nativeConstructorName] = wrapperConstructor;
+      }
+    }
+  });
+
+  if (!window.EventTarget)
+    window.EventTarget = scope.WrapperEventTarget;
+
+})(this.ShadowDOMPolyfill);

--- a/test/custom-element.js
+++ b/test/custom-element.js
@@ -6,20 +6,13 @@
 
 suite('Custom Element', function() {
 
-  var rewrap = ShadowDOMPolyfill.rewrap;
-  var unwrap = ShadowDOMPolyfill.unwrap;
-  var wrap = ShadowDOMPolyfill.wrap;
-
   test('Correct Wrapper for Custom Element', function() {
 
     function MyElement() {};
-    MyElement.prototype = Object.create(HTMLUnknownElement.prototype);
+    MyElement.prototype = Object.create(HTMLElement.prototype);
     MyElement.prototype.customMethod = function() {};
     // make a DOM instance
     var div = document.createElement('div');
-    // strip wrapper (TODO(sjmiles): should we make api for this?)
-    div = unwrap(div);
-    rewrap(div);
     // implement custom API
     if (Object.__proto__) {
       // for browsers that support __proto__
@@ -32,10 +25,6 @@ suite('Custom Element', function() {
     }
     assert.typeOf(div.customMethod, 'function',
                   'plain custom element has custom function');
-    // wrap
-    var wrapper = wrap(div);
-    assert.typeOf(wrapper.customMethod, 'function',
-        'wrapped custom element has custom function');
   });
 
 });

--- a/test/events.js
+++ b/test/events.js
@@ -65,8 +65,10 @@ suite('Events', function() {
   });
 
   test('addEventListener', function() {
-    var div1 = document.createElement('div');
-    var div2 = document.createElement('div');
+    div = document.createElement('div');
+    wrap(document).body.appendChild(div);
+    var div1 = div.appendChild(document.createElement('div'));
+    var div2 = div.appendChild(document.createElement('div'));
     var calls = 0;
     function f(e) {
       calls++;
@@ -93,7 +95,8 @@ suite('Events', function() {
   });
 
   test('removeEventListener', function() {
-    var div = document.createElement('div');
+    div = document.createElement('div');
+    wrap(document).body.appendChild(div);
     var calls = 0;
     function f(e) {
       calls++;
@@ -156,7 +159,8 @@ suite('Events', function() {
   });
 
   test('mouse event', function() {
-    var div = document.createElement('div');
+    div = document.createElement('div');
+    wrap(document).body.appendChild(div);
     var called = false;
     div.addEventListener('click', function(e) {
       called = true;

--- a/test/wrappers.js
+++ b/test/wrappers.js
@@ -170,4 +170,11 @@ suite('Wrapper creation', function() {
     assert.isFalse(doc.contains(textNode));
   });
 
+  test('instanceof', function() {
+    var div = document.createElement('div');
+    assert.instanceOf(div, HTMLElement);
+    assert.instanceOf(div, Element);
+    assert.instanceOf(div, EventTarget);
+  });
+
 });


### PR DESCRIPTION
Now you can do `element instanceof HTMLElement` and it will still work.
