### PR TITLE
Fix issue with Firefox old DOM bindings

### DIFF
--- a/src/wrappers/EventTarget.js
+++ b/src/wrappers/EventTarget.js
@@ -300,11 +300,11 @@
    * @param {!Node} original The original DOM node, aka, the visual DOM node.
    * @constructor
    */
-  var WrapperEvent = function Event(original) {
+  var WrapperEvent = function Event(impl) {
     /**
      * @type {!Event}
      */
-    this.impl = original;
+    this.impl = impl;
   };
 
   WrapperEvent.prototype = {
@@ -371,11 +371,11 @@
    * @param {!Node} original The original DOM node, aka, the visual DOM node.
    * @constructor
    */
-  var WrapperEventTarget = function EventTarget(original) {
+  var WrapperEventTarget = function EventTarget(impl) {
     /**
      * @type {!Node}
      */
-    this.impl = original;
+    this.impl = impl;
   };
 
   var originalAddEventListener = Node.prototype.addEventListener;

--- a/src/wrappers/HTMLElement.js
+++ b/src/wrappers/HTMLElement.js
@@ -169,7 +169,7 @@
 
   // HTMLElement is abstract so we use a subclass that has no members.
   registerWrapper(HTMLElement, WrapperHTMLElement,
-                  document.createElement('span'));
+                  document.createElement('b'));
 
   scope.WrapperHTMLElement = WrapperHTMLElement;
 

--- a/src/wrappers/Node.js
+++ b/src/wrappers/Node.js
@@ -82,7 +82,7 @@
     wrapper.firstChild_ = wrapper.lastChild_ = null;
   }
 
-  var originalNode = Node;
+  var OriginalNode = Node;
 
   /**
    * This represents a logical DOM node.
@@ -91,7 +91,7 @@
    * @extends {WrapperEventTarget}
    */
   var WrapperNode = function Node(original) {
-    assert(original instanceof originalNode);
+    assert(original instanceof OriginalNode);
 
     WrapperEventTarget.call(this, original);
 

--- a/src/wrappers/override-constructors.js
+++ b/src/wrappers/override-constructors.js
@@ -22,4 +22,95 @@
   if (!window.EventTarget)
     window.EventTarget = scope.WrapperEventTarget;
 
+  // This is a list of the elements we currently override the global constructor
+  // for.
+  var elements = {
+    'a': 'HTMLAnchorElement',
+    'applet': 'HTMLAppletElement',
+    'area': 'HTMLAreaElement',
+    'audio': 'HTMLAudioElement',
+    'br': 'HTMLBRElement',
+    'base': 'HTMLBaseElement',
+    'body': 'HTMLBodyElement',
+    'button': 'HTMLButtonElement',
+    'canvas': 'HTMLCanvasElement',
+    // 'command': 'HTMLCommandElement',  // Not fully implemented in Gecko.
+    'dl': 'HTMLDListElement',
+    'datalist': 'HTMLDataListElement',
+    'dir': 'HTMLDirectoryElement',
+    'div': 'HTMLDivElement',
+    'embed': 'HTMLEmbedElement',
+    'fieldset': 'HTMLFieldSetElement',
+    'font': 'HTMLFontElement',
+    'form': 'HTMLFormElement',
+    'frame': 'HTMLFrameElement',
+    'frameset': 'HTMLFrameSetElement',
+    'hr': 'HTMLHRElement',
+    'head': 'HTMLHeadElement',
+    'h1': 'HTMLHeadingElement',
+    'html': 'HTMLHtmlElement',
+    'iframe': 'HTMLIFrameElement',
+
+    // Uses HTMLSpanElement in Firefox.
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=843881
+    // 'image',
+
+    'input': 'HTMLInputElement',
+    'li': 'HTMLLIElement',
+    'label': 'HTMLLabelElement',
+    'legend': 'HTMLLegendElement',
+    'link': 'HTMLLinkElement',
+    'map': 'HTMLMapElement',
+    // 'media', Covered by audio and video
+    'menu': 'HTMLMenuElement',
+    'menuitem': 'HTMLMenuItemElement',
+    'meta': 'HTMLMetaElement',
+    'meter': 'HTMLMeterElement',
+    'del': 'HTMLModElement',
+    'ol': 'HTMLOListElement',
+    'object': 'HTMLObjectElement',
+    'optgroup': 'HTMLOptGroupElement',
+    'option': 'HTMLOptionElement',
+    'output': 'HTMLOutputElement',
+    'p': 'HTMLParagraphElement',
+    'param': 'HTMLParamElement',
+    'pre': 'HTMLPreElement',
+    'progress': 'HTMLProgressElement',
+    'q': 'HTMLQuoteElement',
+    'script': 'HTMLScriptElement',
+    'select': 'HTMLSelectElement',
+    'source': 'HTMLSourceElement',
+    'span': 'HTMLSpanElement',
+    'style': 'HTMLStyleElement',
+    'caption': 'HTMLTableCaptionElement',
+    // WebKit and Moz are wrong:
+    // https://bugs.webkit.org/show_bug.cgi?id=111469
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=848096
+    // 'td': 'HTMLTableCellElement',
+    'col': 'HTMLTableColElement',
+    'table': 'HTMLTableElement',
+    'tr': 'HTMLTableRowElement',
+    'thead': 'HTMLTableSectionElement',
+    'tbody': 'HTMLTableSectionElement',
+    'textarea': 'HTMLTextAreaElement',
+    'title': 'HTMLTitleElement',
+    'ul': 'HTMLUListElement',
+    'video': 'HTMLVideoElement',
+  };
+
+  function overrideConstructor(tagName) {
+    var nativeConstructorName = elements[tagName];
+    var nativeConstructor = window[nativeConstructorName];
+    if (!nativeConstructor)
+      return;
+    var element = document.createElement(tagName);
+    var wrapperConstructor = element.constructor;
+    window[nativeConstructorName] = wrapperConstructor;
+  }
+
+  Object.keys(elements).forEach(overrideConstructor);
+
+  // Export for testing.
+  scope.knownElements = elements;
+
 })(this.ShadowDOMPolyfill);

--- a/test/wrappers.js
+++ b/test/wrappers.js
@@ -10,6 +10,7 @@ suite('Wrapper creation', function() {
   var unwrap = ShadowDOMPolyfill.unwrap;
   var rewrap = ShadowDOMPolyfill.rewrap;
   var resetNodePointers = ShadowDOMPolyfill.resetNodePointers;
+  var knownElements = ShadowDOMPolyfill.knownElements;
 
   test('Br element wrapper', function() {
     var br = document.createElement('br');
@@ -18,90 +19,15 @@ suite('Wrapper creation', function() {
     assert.isTrue(Object.getPrototypeOf(br).hasOwnProperty('clear'));
   });
 
-  var elements = {
-    'a': window.HTMLAnchorElement,
-    'applet': window.HTMLAppletElement,
-    'area': window.HTMLAreaElement,
-    'audio': window.HTMLAudioElement,
-    'br': window.HTMLBRElement,
-    'base': window.HTMLBaseElement,
-    'body': window.HTMLBodyElement,
-    'button': window.HTMLButtonElement,
-    'canvas': window.HTMLCanvasElement,
-    // 'command': window.HTMLCommandElement,  // Not fully implemented in Gecko.
-    'dl': window.HTMLDListElement,
-    'datalist': window.HTMLDataListElement,
-    'dir': window.HTMLDirectoryElement,
-    'div': window.HTMLDivElement,
-    'embed': window.HTMLEmbedElement,
-    'fieldset': window.HTMLFieldSetElement,
-    'font': window.HTMLFontElement,
-    'form': window.HTMLFormElement,
-    'frame': window.HTMLFrameElement,
-    'frameset': window.HTMLFrameSetElement,
-    'hr': window.HTMLHRElement,
-    'head': window.HTMLHeadElement,
-    'h1': window.HTMLHeadingElement,
-    'html': window.HTMLHtmlElement,
-    'iframe': window.HTMLIFrameElement,
-
-    // Uses HTMLSpanElement in Firefox.
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=843881
-    // 'image',
-
-    'input': window.HTMLInputElement,
-    'li': window.HTMLLIElement,
-    'label': window.HTMLLabelElement,
-    'legend': window.HTMLLegendElement,
-    'link': window.HTMLLinkElement,
-    'map': window.HTMLMapElement,
-    // // 'media', Covered by audio and video
-    'menu': window.HTMLMenuElement,
-    'menuitem': window.HTMLMenuItemElement,
-    'meta': window.HTMLMetaElement,
-    'meter': window.HTMLMeterElement,
-    'del': window.HTMLModElement,
-    'ol': window.HTMLOListElement,
-    'object': window.HTMLObjectElement,
-    'optgroup': window.HTMLOptGroupElement,
-    'option': window.HTMLOptionElement,
-    'output': window.HTMLOutputElement,
-    'p': window.HTMLParagraphElement,
-    'param': window.HTMLParamElement,
-    'pre': window.HTMLPreElement,
-    'progress': window.HTMLProgressElement,
-    'q': window.HTMLQuoteElement,
-    'script': window.HTMLScriptElement,
-    'select': window.HTMLSelectElement,
-    'source': window.HTMLSourceElement,
-    'span': window.HTMLSpanElement,
-    'style': window.HTMLStyleElement,
-    'caption': window.HTMLTableCaptionElement,
-    // WebKit and Moz are wrong:
-    // https://bugs.webkit.org/show_bug.cgi?id=111469
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=848096
-    // 'td': window.HTMLTableCellElement,
-    'col': window.HTMLTableColElement,
-    'table': window.HTMLTableElement,
-    'tr': window.HTMLTableRowElement,
-    'thead': window.HTMLTableSectionElement,
-    'tbody': window.HTMLTableSectionElement,
-    'textarea': window.HTMLTextAreaElement,
-    'title': window.HTMLTitleElement,
-    'ul': window.HTMLUListElement,
-    'video': window.HTMLVideoElement,
-  };
-
-  Object.keys(elements).forEach(function(tagName) {
+  Object.keys(knownElements).forEach(function(tagName) {
     test(tagName, function() {
-      var nativeConstructor = elements[tagName];
-      if (!nativeConstructor)
+      var constructor = window[knownElements[tagName]];
+      if (!constructor)
         return;
 
-      var wrappedElement = document.createElement(tagName);
-      var element = unwrap(wrappedElement);
-      assert.isTrue(element instanceof nativeConstructor);
-      assert.equal(Object.getPrototypeOf(element), nativeConstructor.prototype);
+      var element = document.createElement(tagName);
+      assert.instanceOf(element, constructor);
+      assert.equal(Object.getPrototypeOf(element), constructor.prototype);
     });
   });
 


### PR DESCRIPTION
The old Firefox DOM bindings (still in use for some interfaces) lazily creates
the constructor, and if we have overridden the constructor of one of the super
interfaces we get into a state where the DOM element has both wrapper and non
wrapper constructors on its prototype chain.

This also overrides a list of known HTML element constructors.
