### PR TITLE
Chai assert.instanceOf fails because it does a toString on MouseEvent.

### DIFF
--- a/src/wrappers.js
+++ b/src/wrappers.js
@@ -31,6 +31,7 @@ var ShadowDOMPolyfill = {};
         case 'length':
         case 'name':
         case 'prototype':
+        case 'toString':
           return;
       }
       Object.defineProperty(to, name,

--- a/test/events.js
+++ b/test/events.js
@@ -539,8 +539,7 @@ suite('Events', function() {
     var e = new MouseEvent('mouseover', {relatedTarget: div});
     assert.equal(e.type, 'mouseover');
     assert.equal(e.relatedTarget, div);
-    // Chai's assert.instanceOf fails in Firefox for this.
-    assert.isTrue(e instanceof MouseEvent);
+    assert.instanceOf(e, MouseEvent);
   });
 
 });


### PR DESCRIPTION
The reason why it fails in the polyfill is that we copy the native
`MouseEvent.toString` to `WrapperMouseEvent.toString` and that function is not
generic.

https://github.com/toolkitchen/ShadowDOM/issues/59
