### PR TITLE
Fix issues with window load events.

### DIFF
--- a/src/wrappers/EventTarget.js
+++ b/src/wrappers/EventTarget.js
@@ -166,6 +166,18 @@
   function dispatchEvent(event, originalWrapperTarget) {
     var eventPath = retarget(originalWrapperTarget);
 
+    // For window load events the load event is dispatched at the window but
+    // the target is set to the document.
+    //
+    // http://www.whatwg.org/specs/web-apps/current-work/multipage/the-end.html#the-end
+    //
+    // TODO(arv): Find a loess hacky way to do this.
+    if (event.type === 'load' &&
+        eventPath.length === 2 &&
+        eventPath[0].target instanceof wrappers.Document) {
+      eventPath.shift();
+    }
+
     if (dispatchCapturing(event, eventPath)) {
       if (dispatchAtTarget(event, eventPath)) {
         dispatchBubbling(event, eventPath);

--- a/test/events.js
+++ b/test/events.js
@@ -542,4 +542,19 @@ suite('Events', function() {
     assert.instanceOf(e, MouseEvent);
   });
 
+  test('window on load', function(done) {
+    var iframe = document.createElement('iframe');
+    iframe.src = 'on-load-test.html';
+    wrap(document).body.appendChild(iframe);
+    window.addEventListener('message', function f(e) {
+      var data = e.data;
+      if (data && data[0] === 'iframe-load-done') {
+        assertArrayEqual(['iframe-load-done', true, true, true, true], data);
+        wrap(document).body.removeChild(iframe);
+        window.removeEventListener('message', f);
+        done();
+      }
+    });
+  });
+
 });

--- a/test/on-load-test.html
+++ b/test/on-load-test.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<script src="../shadowdom.js"></script>
+<script>
+
+var wrap = ShadowDOMPolyfill.wrap;
+
+window.addEventListener('load', function(e) {
+  var result = [
+    'iframe-load-done',
+    e.target === wrap(document),
+    e.currentTarget === wrap(window),
+    this === wrap(window),
+    e.eventPhase === Event.AT_TARGET
+  ];
+  parent.postMessage(result, '*');
+});
+
+</script>


### PR DESCRIPTION
Window load events are supposed to be dispatched on the window with the target
set to document and the currentTarget set to the window.

Fixes issue #76 
