### PR TITLE
Fix for calculating the event parent

### DIFF
--- a/src/wrappers/EventTarget.js
+++ b/src/wrappers/EventTarget.js
@@ -46,9 +46,9 @@
       return node.insertionPointParent || scope.getHostForShadowRoot(node)
 
     // 2.
-    var p = node.insertionPointParent;
-    if (p)
-      return p;
+    var distributedEventParent = scope.eventParentTable.get(node);
+    if (distributedEventParent)
+      return distributedEventParent;
 
     // 3.
     if (context && isInsertionPoint(node)) {
@@ -83,7 +83,7 @@
         stack.push(ancestor);  // 3.3.
       }
       var target = stack[stack.length - 1];  // 3.4.
-      targets.push({target: target, ancestor: ancestor});  // 3.5.
+      targets.push({target: target, currentTarget: ancestor});  // 3.5.
       if (isShadowRoot(ancestor))  // 3.6.
         stack.pop();  // 3.6.1.
       ancestor = calculateParent(ancestor, context);  // 3.7.
@@ -196,7 +196,7 @@
 
     for (var i = eventPath.length - 1; i > 0; i--) {
       var target = eventPath[i].target;
-      var currentTarget = eventPath[i].ancestor;
+      var currentTarget = eventPath[i].currentTarget;
       if (target === currentTarget)
         continue;
 
@@ -219,7 +219,7 @@
 
     for (var i = 1; i < eventPath.length; i++) {
       var target = eventPath[i].target;
-      var currentTarget = eventPath[i].ancestor;
+      var currentTarget = eventPath[i].currentTarget;
       if (target === currentTarget)
         phase = Event.AT_TARGET;
       else if (bubbles && !stopImmediatePropagationTable.get(event))
@@ -234,7 +234,7 @@
 
   function invoke(tuple, event, phase) {
     var target = tuple.target;
-    var currentTarget = tuple.ancestor;
+    var currentTarget = tuple.currentTarget;
 
     var listeners = listenersTable.get(currentTarget);
     if (!listeners)

--- a/test/events.js
+++ b/test/events.js
@@ -545,115 +545,409 @@ suite('Events', function() {
   /**
    * Creates a deep tree, (all nodes but the leaf have 1 child)
    */
-  function getPropagationTree(log) {
-    var div = document.createElement('div');
+  function getPropagationTree() {
+    var tree = {};
+    var div = tree.div = document.createElement('div');
     div.innerHTML = '<a><b><c></c></b></a>';
-    var a = div.firstChild;
-    var b = a.firstChild;
-    var c = b.firstChild;
-    var sr = b.createShadowRoot();
+    var a = tree.a = div.firstChild;
+    var b = tree.b = a.firstChild;
+    var c = tree.c = b.firstChild;
+    var sr = tree.sr = b.createShadowRoot();
     sr.innerHTML = '<d><content></content></d>';
-    var d = sr.firstChild;
-    var content = d.firstChild;
-    var sr2 = d.createShadowRoot();
+    var d = tree.d = sr.firstChild;
+    var content = tree.content = d.firstChild;
+    var sr2 = tree.sr2 = d.createShadowRoot();
     sr2.innerHTML = '<e><content></content></e>';
-    var e = sr2.firstChild;
-    var content2 = e.firstChild;
+    var e = tree.e = sr2.firstChild;
+    var content2 = tree.content2 = e.firstChild;
 
     div.offsetWidth;
 
-    var tree = {
-      div: div,
-      a: a,
-      b: b,
-      sr: sr,
-      d: d,      
-      sr2: sr2,
-      e: e,
-      content2: content2,
-      content: content,
-      c: c
-    };
-
-    Object.keys(tree).forEach(function(key) {
-      var node = tree[key];
-      node.displayName = key;
-      [true, false].forEach(function(capture) {
-        node.addEventListener('x', function f(e) {
-          log.push(node.displayName + ' ' + getPhaseName(e));
-          node.removeEventListener('x', f, capture);
-        }, capture);
-      });
-    });
-
     return tree;
+  }
+
+  function getDisplayName(node) {
+    if (!node)
+      return String(node);
+    return node.displayName;
   }
 
   function getPhaseName(event) {
     switch (event.eventPhase) {
       case Event.BUBBLING_PHASE:
-        return 'B';
+        return 'BUBBLING_PHASE';
       case Event.AT_TARGET:
-        return 'T';
+        return 'AT_TARGET';
       case Event.CAPTURING_PHASE:
-        return 'C';
+        return 'CAPTURING_PHASE';
     }
   }
 
+  function addListeners(tree, type, log) {
+    Object.keys(tree).forEach(function(key) {
+      var node = tree[key];
+      node.displayName = key;
+      [true, false].forEach(function(capture) {
+        node.addEventListener(type, function f(e) {
+          assert.equal(e.currentTarget, node);
+          assert.equal(e.currentTarget, this);
+          log.push(getDisplayName(node) + ', ' +
+                   getDisplayName(e.target) + ', ' +
+                   getDisplayName(e.relatedTarget) + ', ' +
+                   getPhaseName(e));
+        }, capture);
+      });
+    });
+  }
+
   test('propagation (bubbles)', function() {
+    var tree = getPropagationTree();
     var log = [];
-    var tree = getPropagationTree(log);
+    addListeners(tree, 'x', log);
 
     var e = new Event('x', {bubbles: true});
     tree.c.dispatchEvent(e);
 
-    // This order is not correct, see issue 79
     var expected = [
-      'div C',
-      'a C',
-      'sr C',
-      'd C',
-      'sr2 C',
-      'e C',
-      'content2 C',
-      'c T',
-      'c T',
-      'content2 B',
-      'e B',
-      'sr2 B',
-      'd B',
-      'sr B',
-      'b T',
-      'b T',
-      'a B',
-      'div B'
+      'div, c, undefined, CAPTURING_PHASE',
+      'a, c, undefined, CAPTURING_PHASE',
+      'b, c, undefined, CAPTURING_PHASE',
+      'sr, c, undefined, CAPTURING_PHASE',
+      'd, c, undefined, CAPTURING_PHASE',
+      'sr2, c, undefined, CAPTURING_PHASE',
+      'e, c, undefined, CAPTURING_PHASE',
+      'content2, c, undefined, CAPTURING_PHASE',
+      'content, c, undefined, CAPTURING_PHASE',
+      'c, c, undefined, AT_TARGET',
+      'c, c, undefined, AT_TARGET',
+      'content, c, undefined, BUBBLING_PHASE',
+      'content2, c, undefined, BUBBLING_PHASE',
+      'e, c, undefined, BUBBLING_PHASE',
+      'sr2, c, undefined, BUBBLING_PHASE',
+      'd, c, undefined, BUBBLING_PHASE',
+      'sr, c, undefined, BUBBLING_PHASE',
+      'b, c, undefined, BUBBLING_PHASE',
+      'a, c, undefined, BUBBLING_PHASE',
+      'div, c, undefined, BUBBLING_PHASE',
     ];
+    assertArrayEqual(expected, log);
 
+    log.length = 0;
+    var e = new Event('x', {bubbles: true});
+    tree.e.dispatchEvent(e);
+
+    var expected = [
+      'div, b, undefined, CAPTURING_PHASE',
+      'a, b, undefined, CAPTURING_PHASE',
+      'sr, d, undefined, CAPTURING_PHASE',
+      'sr2, e, undefined, CAPTURING_PHASE',
+      'e, e, undefined, AT_TARGET',
+      'e, e, undefined, AT_TARGET',
+      'sr2, e, undefined, BUBBLING_PHASE',
+      'd, d, undefined, AT_TARGET',
+      'd, d, undefined, AT_TARGET',
+      'sr, d, undefined, BUBBLING_PHASE',
+      'b, b, undefined, AT_TARGET',
+      'b, b, undefined, AT_TARGET',
+      'a, b, undefined, BUBBLING_PHASE',
+      'div, b, undefined, BUBBLING_PHASE',
+    ];
     assertArrayEqual(expected, log);
   });
 
   test('propagation (bubbles: false)', function() {
+    var tree = getPropagationTree();
     var log = [];
-    var tree = getPropagationTree(log);
+    addListeners(tree, 'x', log);
 
     var e = new Event('x', {bubbles: false});
     tree.c.dispatchEvent(e);
 
-    // This order is not correct, see issue 79
     var expected = [
-      'div C',
-      'a C',
-      'sr C',
-      'd C',
-      'sr2 C',
-      'e C',
-      'content2 C',
-      'c T',
-      'c T',
-      'b T',
-      'b T',
+      'div, c, undefined, CAPTURING_PHASE',
+      'a, c, undefined, CAPTURING_PHASE',
+      'b, c, undefined, CAPTURING_PHASE',
+      'sr, c, undefined, CAPTURING_PHASE',
+      'd, c, undefined, CAPTURING_PHASE',
+      'sr2, c, undefined, CAPTURING_PHASE',
+      'e, c, undefined, CAPTURING_PHASE',
+      'content2, c, undefined, CAPTURING_PHASE',
+      'content, c, undefined, CAPTURING_PHASE',
+      'c, c, undefined, AT_TARGET',
+      'c, c, undefined, AT_TARGET'
     ];
+    assertArrayEqual(expected, log);
 
+    log.length = 0;
+    var e = new Event('x', {bubbles: false});
+    tree.e.dispatchEvent(e);
+
+    var expected = [
+      'div, b, undefined, CAPTURING_PHASE',
+      'a, b, undefined, CAPTURING_PHASE',
+      'sr, d, undefined, CAPTURING_PHASE',
+      'sr2, e, undefined, CAPTURING_PHASE',
+      'e, e, undefined, AT_TARGET',
+      'e, e, undefined, AT_TARGET',
+      'd, d, undefined, AT_TARGET',
+      'd, d, undefined, AT_TARGET',
+      'b, b, undefined, AT_TARGET',
+      'b, b, undefined, AT_TARGET',
+    ];
+    assertArrayEqual(expected, log);
+  });
+
+  test('retarget order', function() {
+    var tree = {};
+    var div = tree.div = document.createElement('div');
+    // wrap(document).body.appendChild(div);
+    div.innerHTML = '<c></c><d></d>';
+    var c = tree.c = div.firstChild;
+    var d = tree.d = div.lastChild;
+    var sr = tree.sr = div.createShadowRoot();
+    sr.innerHTML = '<a><content></content></a>';
+    var a = tree.a = sr.firstChild;
+    var content = tree.content = a.firstChild;
+    var sr2 = tree.sr2 = a.createShadowRoot();
+    sr2.innerHTML = '<b><content></content></b>';
+    var b = tree.b = sr2.firstChild;
+    var content2 = tree.content2 = b.firstChild;
+    var sr3 = tree.sr3 = b.createShadowRoot();
+    sr3.innerHTML = '<content></content>';
+    var content3 = tree.content3 = sr3.firstChild;
+
+    div.offsetWidth;
+
+    var log = [];
+    addListeners(tree, 'mouseover', log);
+
+    // move from d to c, both in the light dom.
+    var event = new MouseEvent('mouseover', {relatedTarget: d, bubbles: true});
+    c.dispatchEvent(event);
+    var expected = [
+      'div, c, d, CAPTURING_PHASE',
+      'sr, c, d, CAPTURING_PHASE',
+      'a, c, d, CAPTURING_PHASE',
+      'sr2, c, d, CAPTURING_PHASE',
+      'b, c, d, CAPTURING_PHASE',
+      'sr3, c, d, CAPTURING_PHASE',
+      'content3, c, d, CAPTURING_PHASE',
+      'content2, c, d, CAPTURING_PHASE',
+      'content, c, d, CAPTURING_PHASE',
+      'c, c, d, AT_TARGET',
+      'c, c, d, AT_TARGET',
+      'content, c, d, BUBBLING_PHASE',
+      'content2, c, d, BUBBLING_PHASE',
+      'content3, c, d, BUBBLING_PHASE',
+      'sr3, c, d, BUBBLING_PHASE',
+      'b, c, d, BUBBLING_PHASE',
+      'sr2, c, d, BUBBLING_PHASE',
+      'a, c, d, BUBBLING_PHASE',
+      'sr, c, d, BUBBLING_PHASE',
+      'div, c, d, BUBBLING_PHASE',
+    ];
+    assertArrayEqual(expected, log);
+
+    // Move from c to b (b in light, c in a shadow)
+    log.length = 0;
+    var event = new MouseEvent('mouseover', {relatedTarget: c, bubbles: true});
+    b.dispatchEvent(event);
+    var expected = [
+      'sr, a, c, CAPTURING_PHASE',
+      'sr2, b, c, CAPTURING_PHASE',
+      'b, b, c, AT_TARGET',
+      'b, b, c, AT_TARGET',
+      'sr2, b, c, BUBBLING_PHASE',
+      'a, a, c, AT_TARGET',
+      'a, a, c, AT_TARGET',
+      'sr, a, c, BUBBLING_PHASE',
+      'div, div, c, AT_TARGET',
+      'div, div, c, AT_TARGET',
+    ];
+    assertArrayEqual(expected, log);
+
+    // Move from b to c (b in light, c in a shadow)
+    log.length = 0;
+    var event = new MouseEvent('mouseover', {relatedTarget: b, bubbles: true});
+    c.dispatchEvent(event);
+    var expected = [
+      'div, c, div, CAPTURING_PHASE',
+      'sr, c, a, CAPTURING_PHASE',
+      'a, c, a, CAPTURING_PHASE',
+      'sr2, c, b, CAPTURING_PHASE',
+      'b, c, b, CAPTURING_PHASE',
+      'sr3, c, b, CAPTURING_PHASE',
+      'content3, c, b, CAPTURING_PHASE',
+      'content2, c, b, CAPTURING_PHASE',
+      'content, c, a, CAPTURING_PHASE',
+      'c, c, div, AT_TARGET',
+      'c, c, div, AT_TARGET',
+      'content, c, a, BUBBLING_PHASE',
+      'content2, c, b, BUBBLING_PHASE',
+      'content3, c, b, BUBBLING_PHASE',
+      'sr3, c, b, BUBBLING_PHASE',
+      'b, c, b, BUBBLING_PHASE',
+      'sr2, c, b, BUBBLING_PHASE',
+      'a, c, a, BUBBLING_PHASE',
+      'sr, c, a, BUBBLING_PHASE',
+      'div, c, div, BUBBLING_PHASE',
+    ];
+    assertArrayEqual(expected, log);
+
+    // a
+    // + sr
+    //   + b
+
+    // Move from a to b (both in shadow)
+    log.length = 0;
+    var event = new MouseEvent('mouseover', {relatedTarget: a, bubbles: true});
+    b.dispatchEvent(event);
+    var expected = [
+      'sr2, b, a, CAPTURING_PHASE',
+      'b, b, a, AT_TARGET',
+      'b, b, a, AT_TARGET',
+      'sr2, b, a, BUBBLING_PHASE',
+    ];
+    assertArrayEqual(expected, log);
+
+    // Move from b to a (both in shadow)
+    log.length = 0;
+    var event = new MouseEvent('mouseover', {relatedTarget: b, bubbles: true});
+    a.dispatchEvent(event);
+    var expected = [];
+    assertArrayEqual(expected, log);
+  });
+
+test('retarget order (multiple shadow roots)', function() {
+    var tree = {};
+    var div = tree.div = document.createElement('div');
+    // wrap(document).body.appendChild(div);
+    div.innerHTML = '<c></c><d></d>';
+    var c = tree.c = div.firstChild;
+    var d = tree.d = div.lastChild;
+    var sr = tree.sr = div.createShadowRoot();
+    sr.innerHTML = '<a><content></content></a>';
+    var a = tree.a = sr.firstChild;
+    var content = tree.content = a.firstChild;
+    var sr2 = tree.sr2 = div.createShadowRoot();
+    sr2.innerHTML = '<b><shadow></shadow></b>';
+    var b = tree.b = sr2.firstChild;
+    var shadow = tree.shadow = b.firstChild;
+    var sr3 = tree.sr3 = div.createShadowRoot();
+    sr3.innerHTML = '<shadow></shadow>';
+    var shadow2 = tree.shadow2 = sr3.firstChild;
+
+    div.offsetWidth;
+
+    var log = [];
+    addListeners(tree, 'mouseover', log);
+
+    // move from d to c, both in the light dom.
+    var event = new MouseEvent('mouseover', {relatedTarget: d, bubbles: true});
+    c.dispatchEvent(event);
+    var expected = [
+      'div, c, d, CAPTURING_PHASE',
+      'sr3, c, d, CAPTURING_PHASE',
+      'shadow2, c, d, CAPTURING_PHASE',
+      'sr2, c, d, CAPTURING_PHASE',
+      'b, c, d, CAPTURING_PHASE',
+      'shadow, c, d, CAPTURING_PHASE',
+      'sr, c, d, CAPTURING_PHASE',
+      'a, c, d, CAPTURING_PHASE',
+      'content, c, d, CAPTURING_PHASE',
+      'c, c, d, AT_TARGET',
+      'c, c, d, AT_TARGET',
+      'content, c, d, BUBBLING_PHASE',
+      'a, c, d, BUBBLING_PHASE',
+      'sr, c, d, BUBBLING_PHASE',
+      'shadow, c, d, BUBBLING_PHASE',
+      'b, c, d, BUBBLING_PHASE',
+      'sr2, c, d, BUBBLING_PHASE',
+      'shadow2, c, d, BUBBLING_PHASE',
+      'sr3, c, d, BUBBLING_PHASE',
+      'div, c, d, BUBBLING_PHASE',
+    ];
+    assertArrayEqual(expected, log);
+
+
+    // Move from c to b (b in light, c in a shadow)
+    log.length = 0;
+    var event = new MouseEvent('mouseover', {relatedTarget: c, bubbles: true});
+    b.dispatchEvent(event);
+    var expected = [
+      'sr3, shadow2, c, CAPTURING_PHASE',
+      'sr2, b, c, CAPTURING_PHASE',
+      'b, b, c, AT_TARGET',
+      'b, b, c, AT_TARGET',
+      'sr2, b, c, BUBBLING_PHASE',
+      'shadow2, shadow2, c, AT_TARGET',
+      'shadow2, shadow2, c, AT_TARGET',
+      'sr3, shadow2, c, BUBBLING_PHASE',
+      'div, div, c, AT_TARGET',
+      'div, div, c, AT_TARGET',
+    ];
+    assertArrayEqual(expected, log);
+
+    // Move from b to c (b in light, c in a shadow)
+    log.length = 0;
+    var event = new MouseEvent('mouseover', {relatedTarget: b, bubbles: true});
+    c.dispatchEvent(event);
+    var expected = [
+      'div, c, div, CAPTURING_PHASE',
+      'sr3, c, shadow2, CAPTURING_PHASE',
+      'shadow2, c, shadow2, CAPTURING_PHASE',
+      'sr2, c, b, CAPTURING_PHASE',
+      'b, c, b, CAPTURING_PHASE',
+      'shadow, c, b, CAPTURING_PHASE',
+      'sr, c, div, CAPTURING_PHASE',
+      'a, c, div, CAPTURING_PHASE',
+      'content, c, div, CAPTURING_PHASE',
+      'c, c, div, AT_TARGET',
+      'c, c, div, AT_TARGET',
+      'content, c, div, BUBBLING_PHASE',
+      'a, c, div, BUBBLING_PHASE',
+      'sr, c, div, BUBBLING_PHASE',
+      'shadow, c, b, BUBBLING_PHASE',
+      'b, c, b, BUBBLING_PHASE',
+      'sr2, c, b, BUBBLING_PHASE',
+      'shadow2, c, shadow2, BUBBLING_PHASE',
+      'sr3, c, shadow2, BUBBLING_PHASE',
+      'div, c, div, BUBBLING_PHASE',
+    ];
+    assertArrayEqual(expected, log);
+
+    // a
+    // + sr
+    //   + b
+
+    // Move from a to b (both in shadow)
+    log.length = 0;
+    var event = new MouseEvent('mouseover', {relatedTarget: a, bubbles: true});
+    b.dispatchEvent(event);
+    var expected = [
+      'sr2, b, shadow, CAPTURING_PHASE',
+      'b, b, shadow, AT_TARGET',
+      'b, b, shadow, AT_TARGET',
+      'sr2, b, shadow, BUBBLING_PHASE',
+    ];
+    assertArrayEqual(expected, log);
+
+    // Move from b to a (both in shadow)
+    log.length = 0;
+    var event = new MouseEvent('mouseover', {relatedTarget: b, bubbles: true});
+    a.dispatchEvent(event);
+    var expected = [
+      'sr2, shadow, b, CAPTURING_PHASE',
+      'b, shadow, b, CAPTURING_PHASE',
+      'sr, a, div, CAPTURING_PHASE',
+      'a, a, div, AT_TARGET',
+      'a, a, div, AT_TARGET',
+      'sr, a, div, BUBBLING_PHASE',
+      'shadow, shadow, b, AT_TARGET',
+      'shadow, shadow, b, AT_TARGET',
+      'b, shadow, b, BUBBLING_PHASE',
+      'sr2, shadow, b, BUBBLING_PHASE',
+    ];
     assertArrayEqual(expected, log);
   });
 


### PR DESCRIPTION
We need to keep track of the event parent when we reditribute insertion points
since we cannot use `node.insertionParent`.

Fixes #79
