### PR TITLE
Fix issue with document.body.innerHTML

### DIFF
--- a/src/wrappers/Node.js
+++ b/src/wrappers/Node.js
@@ -14,6 +14,10 @@
   var unwrap = scope.unwrap;
   var wrap = scope.wrap;
 
+  function assertIsNodeWrapper(node) {
+    assert(node instanceof Node);
+  }
+
   /**
    * Collects nodes from a DocumentFragment or a Node for removal followed
    * by an insertion.
@@ -75,7 +79,7 @@
       childWrapper.previousSibling_ = childWrapper.nextSibling_ = childWrapper.parentNode_ = null;
       var parentNode = childNode.parentNode;
       if (parentNode)
-        parentNode.removeChild(childNode);
+        originalRemoveChild.call(parentNode, childNode);
       childWrapper = nextSibling;
     }
     wrapper.firstChild_ = wrapper.lastChild_ = null;
@@ -137,7 +141,7 @@
   Node.prototype = Object.create(EventTarget.prototype);
   mixin(Node.prototype, {
     appendChild: function(childWrapper) {
-      assert(childWrapper instanceof Node);
+      assertIsNodeWrapper(childWrapper);
 
       this.invalidateShadowRenderer();
 
@@ -164,8 +168,8 @@
       if (!refWrapper)
         return this.appendChild(childWrapper);
 
-      assert(childWrapper instanceof Node);
-      assert(refWrapper instanceof Node);
+      assertIsNodeWrapper(childWrapper);
+      assertIsNodeWrapper(refWrapper);
       assert(refWrapper.parentNode === this);
 
       this.invalidateShadowRenderer();
@@ -193,7 +197,7 @@
     },
 
     removeChild: function(childWrapper) {
-      assert(childWrapper instanceof Node);
+      assertIsNodeWrapper(childWrapper);
       if (childWrapper.parentNode !== this) {
         // TODO(arv): DOMException
         throw new Error('NotFoundError');
@@ -221,8 +225,8 @@
     },
 
     replaceChild: function(newChildWrapper, oldChildWrapper) {
-      assert(newChildWrapper instanceof Node);
-      assert(oldChildWrapper instanceof Node);
+      assertIsNodeWrapper(newChildWrapper);
+      assertIsNodeWrapper(oldChildWrapper);
 
       if (oldChildWrapper.parentNode !== this) {
         // TODO(arv): DOMException

--- a/test/HTMLBodyElement.js
+++ b/test/HTMLBodyElement.js
@@ -85,4 +85,8 @@ suite('HTMLBodyElement', function() {
     doc.body.removeChild(div);
     assert.isNull(div.parentNode);
   });
+
+  testIframe('innerHTML', 'document-body-inner-html.html', function(result) {
+    assertArrayEqual([true, true], result);
+  });
 });

--- a/test/document-body-inner-html.html
+++ b/test/document-body-inner-html.html
@@ -3,14 +3,17 @@
 <script>
 
 var wrap = ShadowDOMPolyfill.wrap;
+var doc = wrap(document);
 
-window.addEventListener('load', function(e) {
+doc.addEventListener('DOMContentLoaded', function(e) {
+  var html = '<a></a><b></b>';
+  doc.body.innerHTML = html;
+
   var result = [
-    e.target === wrap(document),
-    e.currentTarget === wrap(window),
-    this === wrap(window),
-    e.eventPhase === Event.AT_TARGET
+    doc.body.innerHTML === html,
+    document.body.innerHTML === html
   ];
+
   parent.postMessage({
     id: window.location.hash.slice(1),
     result: result

--- a/test/events.js
+++ b/test/events.js
@@ -951,19 +951,8 @@ test('retarget order (multiple shadow roots)', function() {
     assertArrayEqual(expected, log);
   });
 
-  test('window on load', function(done) {
-    var iframe = document.createElement('iframe');
-    iframe.src = 'on-load-test.html';
-    wrap(document).body.appendChild(iframe);
-    window.addEventListener('message', function f(e) {
-      var data = e.data;
-      if (data && data[0] === 'iframe-load-done') {
-        assertArrayEqual(['iframe-load-done', true, true, true, true], data);
-        wrap(document).body.removeChild(iframe);
-        window.removeEventListener('message', f);
-        done();
-      }
-    });
+  testIframe('window on load', 'on-load-test.html', function(result) {
+    assertArrayEqual([true, true, true, true], result);
   });
 
 });

--- a/test/test.main.js
+++ b/test/test.main.js
@@ -30,6 +30,26 @@ function assertArrayEqual(a, b, msg) {
   }
 }
 
+// TODO(arv): Use htmlTest when it has settled down.
+function testIframe(name, src, callback) {
+  var wrap = ShadowDOMPolyfill.wrap;
+  test(name, function(done) {
+    var iframe = document.createElement('iframe');
+    iframe.src = src + '#' + name;
+    iframe.style.cssText = 'position: absolute; top: -10000px';
+    wrap(document).body.appendChild(iframe);
+    window.addEventListener('message', function f(e) {
+      var data = e.data;
+      if (data && data.id === name) {
+        callback(data.result);
+        wrap(document).body.removeChild(iframe);
+        window.removeEventListener('message', f);
+        done();
+      }
+    });
+  });
+}
+
 mocha.setup({
   ui: 'tdd',
   globals: ['console', 'getInterface']


### PR DESCRIPTION
It used to end up calling `document.body.removeChild(realNode)` which does not
work because we have hijacked document.body.removeChild to only work with
wrappers.

Fixes #97
