### PR TITLE
Hard bind window to the window overrides

### DIFF
--- a/test/Window.js
+++ b/test/Window.js
@@ -27,11 +27,19 @@ suite('Window', function() {
       win.removeEventListener('click', f);
     });
 
-    document.body.click();
-    assert.equal(2, calls);
+    addEventListener('click', function f(e) {
+      calls++;
+      assert.equal(this, win);
+      assert.equal(e.target, doc.body);
+      assert.equal(e.currentTarget, this);
+      removeEventListener('click', f);
+    });
 
     document.body.click();
-    assert.equal(2, calls);
+    assert.equal(3, calls);
+
+    document.body.click();
+    assert.equal(3, calls);
   });
 
   test('getComputedStyle', function() {
@@ -42,5 +50,10 @@ suite('Window', function() {
     div = document.createElement('div');
     cs = wrap(window).getComputedStyle(div);
     assert.isTrue(cs != null);
+
+    div = document.createElement('div');
+    cs = getComputedStyle(div);
+    assert.isTrue(cs != null);
   });
+
 });


### PR DESCRIPTION
This allows us to do:

  addEventListener('click', func)

without (window)

Fixes #101
