### PR TITLE
Reset event parent when we redistribute a node.

### DIFF
--- a/src/ShadowRenderer.js
+++ b/src/ShadowRenderer.js
@@ -123,6 +123,12 @@
   }
 
   function resetDistributedChildNodes(insertionPoint) {
+    var oldDistributed = getDistributedChildNodes(insertionPoint);
+    if (oldDistributed) {
+      oldDistributed.forEach(function(node) {
+        eventParentTable.set(node, undefined);
+      });
+    }
     distributedChildNodesTable.set(insertionPoint, []);
   }
 


### PR DESCRIPTION
This was causing the iloop in platform/workbench/menu-button.html
