### PR TITLE
Revert "Reset event parent when we redistribute a node."

### DIFF
--- a/src/ShadowRenderer.js
+++ b/src/ShadowRenderer.js
@@ -123,12 +123,6 @@
   }
 
   function resetDistributedChildNodes(insertionPoint) {
-    var oldDistributed = getDistributedChildNodes(insertionPoint);
-    if (oldDistributed) {
-      oldDistributed.forEach(function(node) {
-        eventParentTable.set(node, undefined);
-      });
-    }
     distributedChildNodesTable.set(insertionPoint, []);
   }
 


### PR DESCRIPTION
This reverts commit e701c2e92632386ccb1a4e886d2884c4e7efa0e2.

Turns out to break redistribution. Will have to do more investigation.

Fixes https://github.com/toolkitchen/toolkit/issues/102
