### PR TITLE
Rerender reprojection

### DIFF
--- a/src/ShadowRenderer.js
+++ b/src/ShadowRenderer.js
@@ -123,12 +123,6 @@
   }
 
   function resetDistributedChildNodes(insertionPoint) {
-    var oldDistributed = getDistributedChildNodes(insertionPoint);
-    if (oldDistributed) {
-      oldDistributed.forEach(function(node) {
-        eventParentTable.set(node, undefined);
-      });
-    }
     distributedChildNodesTable.set(insertionPoint, []);
   }
 

--- a/src/ShadowRenderer.js
+++ b/src/ShadowRenderer.js
@@ -104,22 +104,26 @@
   }
 
   var distributedChildNodesTable = new SideTable();
-  var shadowDOMRendererTable = new SideTable();
-  var nextOlderShadowTreeTable = new SideTable();
-  var insertionParentTable = new SideTable();
   var eventParentTable = new SideTable();
+  var insertionParentTable = new SideTable();
+  var nextOlderShadowTreeTable = new SideTable();
+  var rendererForHostTable = new SideTable();
+  var shadowDOMRendererTable = new SideTable();
 
   function distributeChildToInsertionPoint(child, insertionPoint) {
     getDistributedChildNodes(insertionPoint).push(child);
     insertionParentTable.set(child, insertionPoint);
 
+    // If we have "a -> content1" and we now get (a, content2) the
+    // event parent chaing needs to be "a -> content1 -> content2".
     var eventParent = child;
     var tmp;
     while (tmp = eventParentTable.get(eventParent)) {
       eventParent = tmp;
     }
-    if (eventParent !== insertionPoint)
-      eventParentTable.set(eventParent, insertionPoint);
+
+    eventParentTable.set(eventParent, insertionPoint);
+    eventParentTable.set(insertionPoint, undefined);
   }
 
   function resetDistributedChildNodes(insertionPoint) {
@@ -181,12 +185,9 @@
     if (!anyRemoved)
       return pool;
 
-    var newPool = [];
-    for (var i = 0; i < pool.length; i++) {
-      if (pool[i] !== undefined)
-        newPool.push(pool[i]);
-    }
-    return newPool;
+    return pool.filter(function(item) {
+      return item !== undefined;
+    });
   }
 
   // Matching Insertion Points
@@ -283,6 +284,15 @@
     this.associateNode(host);
   }
 
+  function getRendererForHost(host) {
+    var renderer = rendererForHostTable.get(host);
+    if (!renderer) {
+      renderer = new ShadowRenderer(host);
+      rendererForHostTable.set(host, renderer);
+    }
+    return renderer;
+  }
+
   ShadowRenderer.prototype = {
     // http://dvcs.w3.org/hg/webcomponents/raw-file/tip/spec/shadow/index.html#rendering-shadow-trees
     render: function() {
@@ -318,7 +328,7 @@
     renderNode: function(visualParent, tree, node, isNested) {
       if (isShadowHost(node)) {
         this.appendChild(visualParent, node);
-        var renderer = new ShadowRenderer(node);
+        var renderer = getRendererForHost(node);
         renderer.render();
       } else if (isInsertionPoint(node)) {
         this.renderInsertionPoint(visualParent, tree, node, isNested);
@@ -451,21 +461,21 @@
 
   function isInsertionPoint(node) {
     // Should this include <shadow>?
-    return node.tagName == 'CONTENT';
+    return node.localName === 'content';
   }
 
   function isActiveInsertionPoint(node) {
     // <content> inside another <content> or <shadow> is considered inactive.
-    return node.tagName === 'CONTENT';
+    return node.localName === 'content';
   }
 
   function isShadowInsertionPoint(node) {
-    return node.tagName === 'SHADOW';
+    return node.localName === 'shadow';
   }
 
   function isActiveShadowInsertionPoint(node) {
     // <shadow> inside another <content> or <shadow> is considered inactive.
-    return node.tagName === 'SHADOW';
+    return node.localName === 'shadow';
   }
 
   function isShadowHost(shadowHost) {
@@ -491,9 +501,7 @@
   }
 
   function assignShadowTreeToShadowInsertionPoint(tree, point) {
-    // TODO: No one is reading the map below.
-    // console.log('Assign %o to %o', tree, point);
-    // treeToShadowInsertionPointMap.set(tree, point);
+    insertionParentTable.set(tree, point);
   }
 
   // http://dvcs.w3.org/hg/webcomponents/raw-file/tip/spec/shadow/index.html#rendering-shadow-trees
@@ -527,8 +535,8 @@
     }
   });
 
-  scope.ShadowRenderer = ShadowRenderer;
   scope.eventParentTable = eventParentTable;
+  scope.getRendererForHost = getRendererForHost;
   scope.getShadowTrees = getShadowTrees;
   scope.nextOlderShadowTreeTable = nextOlderShadowTreeTable;
   scope.renderAllPending = renderAllPending;

--- a/src/ShadowRenderer.js
+++ b/src/ShadowRenderer.js
@@ -329,6 +329,7 @@
       if (isShadowHost(node)) {
         this.appendChild(visualParent, node);
         var renderer = getRendererForHost(node);
+        renderer.dirty = true;  // Need to rerender due to reprojection.
         renderer.render();
       } else if (isInsertionPoint(node)) {
         this.renderInsertionPoint(visualParent, tree, node, isNested);

--- a/src/sidetable.js
+++ b/src/sidetable.js
@@ -16,7 +16,6 @@ if (typeof WeakMap !== 'undefined' && navigator.userAgent.indexOf('Firefox/') < 
     var hasOwnProperty = Object.hasOwnProperty;
     var counter = new Date().getTime() % 1e9;
 
-
     SideTable = function() {
       this.name = '__st' + (Math.random() * 1e9 >>> 0) + (counter++ + '__');
     };

--- a/src/sidetable.js
+++ b/src/sidetable.js
@@ -27,6 +27,9 @@ if (typeof WeakMap !== 'undefined' && navigator.userAgent.indexOf('Firefox/') < 
       },
       get: function(key) {
         return hasOwnProperty.call(key, this.name) ? key[this.name] : undefined;
+      },
+      delete: function(key) {
+        this.set(key, undefined);
       }
     }
   })();

--- a/src/wrappers/Element.js
+++ b/src/wrappers/Element.js
@@ -26,7 +26,7 @@
       var newShadowRoot = new wrappers.ShadowRoot(this);
       shadowRootTable.set(this, newShadowRoot);
 
-      var renderer = new scope.ShadowRenderer(this);
+      var renderer = scope.getRendererForHost(this);
 
       this.invalidateShadowRenderer();
 

--- a/src/wrappers/MutationObserver.js
+++ b/src/wrappers/MutationObserver.js
@@ -38,24 +38,20 @@
     defineWrapGetter(MutationRecord, name);
   });
 
-  if (OriginalMutationRecord) {
-    registerWrapper(OriginalMutationRecord, MutationRecord);
-  } else {
-    // WebKit/Blink does not expose MutationRecord
-    // https://bugs.webkit.org/show_bug.cgi?id=114288
-    // https://code.google.com/p/chromium/issues/detail?id=229416
-
-    [
-      'type',
-      'attributeName',
-      'attributeNamespace',
-      'oldValue'
-    ].forEach(function(name) {
-      defineGetter(MutationRecord, name, function() {
-        return this.impl[name];
-      });
+  // WebKit/Blink treats these as instance properties so we override
+  [
+    'type',
+    'attributeName',
+    'attributeNamespace',
+    'oldValue'
+  ].forEach(function(name) {
+    defineGetter(MutationRecord, name, function() {
+      return this.impl[name];
     });
-  }
+  });
+
+  if (OriginalMutationRecord)
+    registerWrapper(OriginalMutationRecord, MutationRecord);
 
   function wrapRecord(record) {
     return new MutationRecord(record);

--- a/test/events.js
+++ b/test/events.js
@@ -965,5 +965,69 @@ test('retarget order (multiple shadow roots)', function() {
     assert.equal(e, wrap(unwrap(e)));
   });
 
+  test('event path in presence of shadow element', function() {
+    var div = document.createElement('div');
+
+    var menuButton = document.createElement('menu-button');
+    menuButton.innerHTML = '<a></a><b></b>';
+    var a = menuButton.firstChild;
+    var b = menuButton.lastChild;
+
+    var menuButtonSr = menuButton.createShadowRoot();
+    menuButtonSr.innerHTML = '<menu><content name="menu-button"></content></menu>';
+    var menu = menuButtonSr.firstChild;
+    var menuButtonContent = menu.firstChild;
+
+    var selectorSr = menu.createShadowRoot();
+    selectorSr.innerHTML = '<content name="selector"></content>';
+    var selectorContent = selectorSr.firstChild;
+
+    var menuSr = menu.createShadowRoot();
+    menuSr.innerHTML = 'xxx<shadow name="menu"></shadow>xxx';
+    var menuShadow = menuSr.firstElementChild;
+
+    menuButton.offsetWidth;
+
+    var tree = {
+      div: div,
+      menuButton: menuButton,
+      a: a,
+      b: b,
+      menuButtonSr: menuButtonSr,
+      menu: menu,
+      menuButtonContent: menuButtonContent,
+      menuSr: menuSr,
+      menuShadow: menuShadow,
+      selectorSr: selectorSr,
+      selectorContent: selectorContent,
+    };
+
+    var log = [];
+    addListeners(tree, 'x', log);
+
+    a.dispatchEvent(new Event('x', {bubbles: true}));
+
+    var expected = [
+      'menuButton, a, undefined, CAPTURING_PHASE',
+      'menuButtonSr, a, undefined, CAPTURING_PHASE',
+      'menu, a, undefined, CAPTURING_PHASE',
+      'menuSr, a, undefined, CAPTURING_PHASE',
+      'menuShadow, a, undefined, CAPTURING_PHASE',
+      'selectorSr, a, undefined, CAPTURING_PHASE',
+      'selectorContent, a, undefined, CAPTURING_PHASE',
+      'menuButtonContent, a, undefined, CAPTURING_PHASE',
+      'a, a, undefined, AT_TARGET',
+      'a, a, undefined, AT_TARGET',
+      'menuButtonContent, a, undefined, BUBBLING_PHASE',
+      'selectorContent, a, undefined, BUBBLING_PHASE',
+      'selectorSr, a, undefined, BUBBLING_PHASE',
+      'menuShadow, a, undefined, BUBBLING_PHASE',
+      'menuSr, a, undefined, BUBBLING_PHASE',
+      'menu, a, undefined, BUBBLING_PHASE',
+      'menuButtonSr, a, undefined, BUBBLING_PHASE',
+      'menuButton, a, undefined, BUBBLING_PHASE',
+    ];
+    assertArrayEqual(expected, log);
+  });
 
 });

--- a/test/reprojection.js
+++ b/test/reprojection.js
@@ -121,7 +121,8 @@ suite('Shadow DOM reprojection', function() {
     var textNodeB = pShadowRoot.childNodes[2]
     var contentB = pShadowRoot.childNodes[3];
     // call getDistributedNodes before composing the shadowRoots together
-    contentA.getDistributedNodes();
+    var distributedNodes = contentA.getDistributedNodes();
+    assert.equal(distributedNodes.length, 0);
     shadowRoot.appendChild(p);
 
     function testRender() {

--- a/test/reprojection.js
+++ b/test/reprojection.js
@@ -102,4 +102,96 @@ suite('Shadow DOM reprojection', function() {
     testRender();
 
   });
+  
+  test('getDistributedNodes can be called before shadowRoot composition', function() {
+    var host = document.createElement('div');
+    host.innerHTML = '<a></a>';
+    var a = host.firstChild;
+    var shadowRoot = host.createShadowRoot();
+    // create another tag disembodied from the first shadowRoot
+    var p = document.createElement('p');
+    p.innerHTML = '<b></b><content></content>';
+    var b = p.firstChild;
+    var content = p.lastChild;
+    var pShadowRoot = p.createShadowRoot();
+    pShadowRoot.innerHTML =
+        'a: <content select=a></content>b: <content select=b></content>';
+    var textNodeA = pShadowRoot.firstChild;
+    var contentA = pShadowRoot.childNodes[1];
+    var textNodeB = pShadowRoot.childNodes[2]
+    var contentB = pShadowRoot.childNodes[3];
+    // call getDistributedNodes before composing the shadowRoots together
+    contentA.getDistributedNodes();
+    shadowRoot.appendChild(p);
+
+    function testRender() {
+      host.offsetWidth;
+      assert.strictEqual(getVisualInnerHtml(host),
+                         '<p>a: <a></a>b: <b></b></p>');
+
+      expectStructure(host, {
+        firstChild: a,
+        lastChild: a
+      });
+
+      expectStructure(a, {
+        parentNode: host
+      });
+
+
+      expectStructure(shadowRoot, {
+        firstChild: p,
+        lastChild: p
+      });
+
+      expectStructure(p, {
+        parentNode: shadowRoot,
+        firstChild: b,
+        lastChild: content,
+      });
+
+      expectStructure(b, {
+        parentNode: p,
+        nextSibling: content
+      });
+
+      expectStructure(content, {
+        parentNode: p,
+        previousSibling: b
+      });
+
+
+      expectStructure(pShadowRoot, {
+        firstChild: textNodeA,
+        lastChild: contentB
+      });
+
+      expectStructure(textNodeA, {
+        parentNode: pShadowRoot,
+        nextSibling: contentA
+      });
+
+      expectStructure(contentA, {
+        parentNode: pShadowRoot,
+        previousSibling: textNodeA,
+        nextSibling: textNodeB
+      });
+
+      expectStructure(textNodeB, {
+        parentNode: pShadowRoot,
+        previousSibling: contentA,
+        nextSibling: contentB
+      });
+
+      expectStructure(contentB, {
+        parentNode: pShadowRoot,
+        previousSibling: textNodeB
+      });
+    }
+
+    testRender();
+    testRender();
+
+   
+  });
 });


### PR DESCRIPTION
When we are recursively rendering a shadow host we need to ensure it is dirty to render it again. This is because reprojection may be in effect.

Fixes #115
Closes #116
