### PR TITLE
Rerender reprojection

### DIFF
--- a/src/ShadowRenderer.js
+++ b/src/ShadowRenderer.js
@@ -329,6 +329,7 @@
       if (isShadowHost(node)) {
         this.appendChild(visualParent, node);
         var renderer = getRendererForHost(node);
+        renderer.dirty = true;  // Need to rerender due to reprojection.
         renderer.render();
       } else if (isInsertionPoint(node)) {
         this.renderInsertionPoint(visualParent, tree, node, isNested);

--- a/src/sidetable.js
+++ b/src/sidetable.js
@@ -16,7 +16,6 @@ if (typeof WeakMap !== 'undefined' && navigator.userAgent.indexOf('Firefox/') < 
     var hasOwnProperty = Object.hasOwnProperty;
     var counter = new Date().getTime() % 1e9;
 
-
     SideTable = function() {
       this.name = '__st' + (Math.random() * 1e9 >>> 0) + (counter++ + '__');
     };

--- a/test/reprojection.js
+++ b/test/reprojection.js
@@ -121,7 +121,8 @@ suite('Shadow DOM reprojection', function() {
     var textNodeB = pShadowRoot.childNodes[2]
     var contentB = pShadowRoot.childNodes[3];
     // call getDistributedNodes before composing the shadowRoots together
-    contentA.getDistributedNodes();
+    var distributedNodes = contentA.getDistributedNodes();
+    assert.equal(distributedNodes.length, 0);
     shadowRoot.appendChild(p);
 
     function testRender() {

--- a/test/reprojection.js
+++ b/test/reprojection.js
@@ -102,4 +102,96 @@ suite('Shadow DOM reprojection', function() {
     testRender();
 
   });
+  
+  test('getDistributedNodes can be called before shadowRoot composition', function() {
+    var host = document.createElement('div');
+    host.innerHTML = '<a></a>';
+    var a = host.firstChild;
+    var shadowRoot = host.createShadowRoot();
+    // create another tag disembodied from the first shadowRoot
+    var p = document.createElement('p');
+    p.innerHTML = '<b></b><content></content>';
+    var b = p.firstChild;
+    var content = p.lastChild;
+    var pShadowRoot = p.createShadowRoot();
+    pShadowRoot.innerHTML =
+        'a: <content select=a></content>b: <content select=b></content>';
+    var textNodeA = pShadowRoot.firstChild;
+    var contentA = pShadowRoot.childNodes[1];
+    var textNodeB = pShadowRoot.childNodes[2]
+    var contentB = pShadowRoot.childNodes[3];
+    // call getDistributedNodes before composing the shadowRoots together
+    contentA.getDistributedNodes();
+    shadowRoot.appendChild(p);
+
+    function testRender() {
+      host.offsetWidth;
+      assert.strictEqual(getVisualInnerHtml(host),
+                         '<p>a: <a></a>b: <b></b></p>');
+
+      expectStructure(host, {
+        firstChild: a,
+        lastChild: a
+      });
+
+      expectStructure(a, {
+        parentNode: host
+      });
+
+
+      expectStructure(shadowRoot, {
+        firstChild: p,
+        lastChild: p
+      });
+
+      expectStructure(p, {
+        parentNode: shadowRoot,
+        firstChild: b,
+        lastChild: content,
+      });
+
+      expectStructure(b, {
+        parentNode: p,
+        nextSibling: content
+      });
+
+      expectStructure(content, {
+        parentNode: p,
+        previousSibling: b
+      });
+
+
+      expectStructure(pShadowRoot, {
+        firstChild: textNodeA,
+        lastChild: contentB
+      });
+
+      expectStructure(textNodeA, {
+        parentNode: pShadowRoot,
+        nextSibling: contentA
+      });
+
+      expectStructure(contentA, {
+        parentNode: pShadowRoot,
+        previousSibling: textNodeA,
+        nextSibling: textNodeB
+      });
+
+      expectStructure(textNodeB, {
+        parentNode: pShadowRoot,
+        previousSibling: contentA,
+        nextSibling: contentB
+      });
+
+      expectStructure(contentB, {
+        parentNode: pShadowRoot,
+        previousSibling: textNodeB
+      });
+    }
+
+    testRender();
+    testRender();
+
+   
+  });
 });


### PR DESCRIPTION
When we are recursively rendering a shadow host we need to ensure it is dirty to render it again. This is because reprojection may be in effect.

Fixes #115
Closes #116
