### PR TITLE
Query selector

### DIFF
--- a/shadowdom.js
+++ b/shadowdom.js
@@ -21,6 +21,7 @@
     'wrappers/EventTarget.js',
     'wrappers/NodeList.js',
     'wrappers/Node.js',
+    'querySelector.js',
     'wrappers/node-interfaces.js',
     'wrappers/CharacterData.js',
     'wrappers/Element.js',

--- a/src/ShadowRenderer.js
+++ b/src/ShadowRenderer.js
@@ -225,10 +225,6 @@
     }
   }
 
-  var matchesSelector = oneOf(document.documentElement,
-      ['matchesSelector', 'msMatchesSelector', 'mozMatchesSelector',
-      'webkitMatchesSelector']);
-
   /**
    * @param {Element} node
    * @oaram {Element} point The insertion point element.
@@ -255,7 +251,7 @@
       return false;
 
     try {
-      return node[matchesSelector](select);
+      return node.matches(select);
     } catch (ex) {
       // Invalid selector.
       return false;

--- a/src/querySelector.js
+++ b/src/querySelector.js
@@ -1,0 +1,70 @@
+// Copyright 2013 The Toolkitchen Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+(function(scope) {
+  'use strict';
+
+  function findOne(node, selector) {
+    var m, el = node.firstElementChild;
+    while (el) {
+      if (el.matches(selector))
+        return el;
+      m = findOne(el, selector);
+      if (m)
+        return m;
+      el = el.nextElementSibling;
+    }
+    return null;
+  }
+
+  function findAll(node, selector, results) {
+    var el = node.firstElementChild;
+    while (el) {
+      if (el.matches(selector))
+        results[results.length++] = el;
+      findAll(el, selector, results);
+      el = el.nextElementSibling;
+    }
+    return results;
+  }
+
+  // find and findAll will only match Simple Selectors,
+  // Structural Pseudo Classes are not guarenteed to be correct
+  // http://www.w3.org/TR/css3-selectors/#simple-selectors
+
+  var SelectorsInterface = {
+    querySelector: function(selector) {
+      return findOne(this, selector);
+    },
+    querySelectorAll: function(selector) {
+      return findAll(this, selector, new NodeList())
+    }
+  };
+
+  var GetElementsByInterface = {
+    getElementsByTagName: function(tagName) {
+      // TODO(arv): Check tagName?
+      return this.querySelectorAll(tagName);
+    },
+    getElementsByClassName: function(className) {
+      // TODO(arv): Check className?
+      return this.querySelectorAll('.' + className);
+    },
+    getElementsByTagNameNS: function(ns, tagName) {
+      // TODO(arv): Check tagName?
+      var result = new NodeList;
+      var els = this.getElementsByTagName(tagName);
+      for (var i = 0, j = 0; i < els.length; i++) {
+        if (els[i].namespace === ns)
+          result[j++] = els[i];
+      }
+      result.length = j;
+      return result;
+    }
+  };
+
+  scope.GetElementsByInterface = GetElementsByInterface;
+  scope.SelectorsInterface = SelectorsInterface;
+
+})(this.ShadowDOMPolyfill);

--- a/src/wrappers/Element.js
+++ b/src/wrappers/Element.js
@@ -6,6 +6,7 @@
   'use strict';
 
   var ChildNodeInterface = scope.ChildNodeInterface;
+  var GetElementsByInterface = scope.GetElementsByInterface;
   var Node = scope.wrappers.Node;
   var ParentNodeInterface = scope.ParentNodeInterface;
   var SelectorsInterface = scope.SelectorsInterface;
@@ -16,6 +17,12 @@
 
   var shadowRootTable = new SideTable();
   var OriginalElement = window.Element;
+
+  var originalMatches =
+      OriginalElement.prototype.matches ||
+      OriginalElement.prototype.mozMatchesSelector ||
+      OriginalElement.prototype.msMatchesSelector ||
+      OriginalElement.prototype.webkitMatchesSelector;
 
   function Element(node) {
     Node.call(this, node);
@@ -43,20 +50,17 @@
       // the rendering content[select] or if it effects the value of a content
       // select.
       this.invalidateShadowRenderer();
+    },
+
+    matches: function(selector) {
+      return originalMatches.call(this.impl, selector);
     }
   });
 
   mixin(Element.prototype, ChildNodeInterface);
+  mixin(Element.prototype, GetElementsByInterface);
   mixin(Element.prototype, ParentNodeInterface);
   mixin(Element.prototype, SelectorsInterface);
-
-  [
-    'getElementsByTagName',
-    'getElementsByTagNameNS',
-    'getElementsByClassName'
-  ].forEach(function(name) {
-    addWrapNodeListMethod(Element, name);
-  });
 
   registerWrapper(OriginalElement, Element);
 

--- a/src/wrappers/generic.js
+++ b/src/wrappers/generic.js
@@ -5,6 +5,7 @@
 (function(scope) {
   'use strict';
 
+  var GetElementsByInterface = scope.GetElementsByInterface;
   var ParentNodeInterface = scope.ParentNodeInterface;
   var SelectorsInterface = scope.SelectorsInterface;
   var mixin = scope.mixin;
@@ -13,6 +14,7 @@
   var DocumentFragment = registerObject(document.createDocumentFragment());
   mixin(DocumentFragment.prototype, ParentNodeInterface);
   mixin(DocumentFragment.prototype, SelectorsInterface);
+  mixin(DocumentFragment.prototype, GetElementsByInterface);
 
   var Text = registerObject(document.createTextNode(''));
   var Comment = registerObject(document.createComment(''));

--- a/src/wrappers/node-interfaces.js
+++ b/src/wrappers/node-interfaces.js
@@ -66,17 +66,7 @@
     }
   };
 
-  var SelectorsInterface = {
-    querySelector: function(s) {
-      return wrap(this.impl.querySelector(s));
-    },
-    querySelectorAll: function(s) {
-      return wrapNodeList(this.impl.querySelectorAll(s));
-    }
-  };
-
   scope.ChildNodeInterface = ChildNodeInterface;
   scope.ParentNodeInterface = ParentNodeInterface;
-  scope.SelectorsInterface = SelectorsInterface;
 
 })(this.ShadowDOMPolyfill);

--- a/test/Document.js
+++ b/test/Document.js
@@ -8,6 +8,15 @@ suite('Document', function() {
 
   var wrap = ShadowDOMPolyfill.wrap;
 
+  var div;
+  teardown(function() {
+    if (div) {
+      if (div.parentNode)
+        div.parentNode.removeChild(div);
+      div = undefined;
+    }
+  });
+
   test('Ensure Document has ParentNodeInterface', function() {
     var doc = wrap(document).implementation.createHTMLDocument('');
     assert.equal(doc.firstElementChild.tagName, 'HTML');
@@ -50,6 +59,28 @@ suite('Document', function() {
     assert.isTrue(elements2[0] instanceof HTMLElement);
     assert.equal(doc.body, elements2[0]);
     assert.equal(doc.body, elements2.item(0));
+
+    div = document.body.appendChild(document.createElement('div'));
+    div.innerHTML = '<aa></aa><aa></aa>';
+    var aa1 = div.firstChild;
+    var aa2 = div.lastChild;
+
+    var sr = div.createShadowRoot();
+    sr.innerHTML = '<aa></aa><aa></aa>';
+    var aa3 = sr.firstChild;
+    var aa4 = sr.lastChild;
+
+    div.offsetHeight;
+
+    var elements = document.getElementsByTagName('aa');
+    assert.equal(elements.length, 2);
+    assert.equal(elements[0], aa1);
+    assert.equal(elements[1], aa2);
+
+    var elements = sr.getElementsByTagName('aa');
+    assert.equal(elements.length, 2);
+    assert.equal(elements[0], aa3);
+    assert.equal(elements[1], aa4);
   });
 
   test('querySelectorAll', function() {
@@ -66,6 +97,28 @@ suite('Document', function() {
     assert.equal(elements2.length, 1);
     assert.isTrue(elements2[0] instanceof HTMLElement);
     assert.equal(doc.body, elements2[0]);
+
+    div = document.body.appendChild(document.createElement('div'));
+    div.innerHTML = '<aa></aa><aa></aa>';
+    var aa1 = div.firstChild;
+    var aa2 = div.lastChild;
+
+    var sr = div.createShadowRoot();
+    sr.innerHTML = '<aa></aa><aa></aa>';
+    var aa3 = sr.firstChild;
+    var aa4 = sr.lastChild;
+
+    div.offsetHeight;
+
+    var elements = document.querySelectorAll('aa');
+    assert.equal(elements.length, 2);
+    assert.equal(elements[0], aa1);
+    assert.equal(elements[1], aa2);
+
+    var elements = sr.querySelectorAll('aa');
+    assert.equal(elements.length, 2);
+    assert.equal(elements[0], aa3);
+    assert.equal(elements[1], aa4);
   });
 
   test('addEventListener', function() {

--- a/test/Element.js
+++ b/test/Element.js
@@ -6,6 +6,22 @@
 
 suite('Element', function() {
 
+  test('querySelector', function() {
+    var div = document.createElement('div');
+    div.innerHTML = '<a><b></b></a>';
+    var b = div.firstChild.firstChild;
+    assert.equal(div.querySelector('b'), b);
+
+    var sr = div.createShadowRoot();
+    sr.innerHTML = '<b></b>';
+    var srb = sr.firstChild;
+
+    div.offsetHeight;
+
+    assert.equal(div.querySelector('b'), b);
+    assert.equal(sr.querySelector('b'), srb);
+  });
+
   test('querySelectorAll', function() {
     var div = document.createElement('div');
     div.innerHTML = '<a>0</a><a>1</a>';
@@ -18,6 +34,23 @@ suite('Element', function() {
     assert.equal(as.item(0), a0);
     assert.equal(as[1], a1);
     assert.equal(as.item(1), a1);
+
+    var sr = div.createShadowRoot();
+    sr.innerHTML = '<a>3</a><a>4</a>';
+    var a3 = sr.firstChild;
+    var a4 = sr.lastChild;
+
+    div.offsetHeight;
+
+    var as = div.querySelectorAll('a');
+    assert.equal(as.length, 2);
+    assert.equal(as[0], a0);
+    assert.equal(as[1], a1);
+
+    var as = sr.querySelectorAll('a');
+    assert.equal(as.length, 2);
+    assert.equal(as[0], a3);
+    assert.equal(as[1], a4);
   });
 
   test('getElementsByTagName', function() {
@@ -32,5 +65,53 @@ suite('Element', function() {
     assert.equal(as.item(0), a0);
     assert.equal(as[1], a1);
     assert.equal(as.item(1), a1);
+
+    var sr = div.createShadowRoot();
+    sr.innerHTML = '<a>3</a><a>4</a>';
+    var a3 = sr.firstChild;
+    var a4 = sr.lastChild;
+
+    div.offsetHeight;
+
+    var as = div.getElementsByTagName('a');
+    assert.equal(as.length, 2);
+    assert.equal(as[0], a0);
+    assert.equal(as[1], a1);
+
+    var as = sr.getElementsByTagName('a');
+    assert.equal(as.length, 2);
+    assert.equal(as[0], a3);
+    assert.equal(as[1], a4);
+  });
+
+  test('getElementsByClassName', function() {
+    var div = document.createElement('div');
+    div.innerHTML = '<span class=a>0</span><span class=a>1</span>';
+    var a0 = div.firstChild;
+    var a1 = div.lastChild;
+
+    var as = div.getElementsByClassName('a');
+    assert.equal(as.length, 2);
+    assert.equal(as[0], a0);
+    assert.equal(as.item(0), a0);
+    assert.equal(as[1], a1);
+    assert.equal(as.item(1), a1);
+
+    var sr = div.createShadowRoot();
+    sr.innerHTML = '<span class=a>3</span><span class=a>4</span>';
+    var a3 = sr.firstChild;
+    var a4 = sr.lastChild;
+
+    div.offsetHeight;
+
+    var as = div.getElementsByClassName('a');
+    assert.equal(as.length, 2);
+    assert.equal(as[0], a0);
+    assert.equal(as[1], a1);
+
+    var as = sr.getElementsByClassName('a');
+    assert.equal(as.length, 2);
+    assert.equal(as[0], a3);
+    assert.equal(as[1], a4);
   });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -185,7 +185,7 @@ suite('Shadow DOM', function() {
 
       // :visited cannot be queried in JS.
 
-      // :target is not supported. matchesSelector(':target') does not seem to
+      // :target is not supported. matches(':target') does not seem to
       // work in WebKit nor Firefox.
 
       testRender(':enabled',


### PR DESCRIPTION
This is based on https://github.com/toolkitchen/ShadowDOM/tree/query-selecto

It also implements `getElementsByTagName`, `getElementsByTagNameNS` and `getElementsByClassName`.

It also installs `matches` on `Element` so we only have to do the feature detection in a single place.
