### PR TITLE
Wrap document.write

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "buildbot"]
 	path = buildbot
 	url = https://github.com/toolkitchen/buildbot.git
+[submodule "tools"]
+	path = tools
+	url = git@github.com:toolkitchen/tools.git

--- a/src/wrappers/Document.js
+++ b/src/wrappers/Document.js
@@ -56,6 +56,7 @@
   ].forEach(wrapMethod);
 
   var originalAdoptNode = document.adoptNode;
+  var originalWrite = document.write;
 
   mixin(Document.prototype, {
     adoptNode: function(node) {
@@ -64,6 +65,17 @@
     },
     elementFromPoint: function(x, y) {
       return elementFromPoint(this, this, x, y);
+    },
+    write: function(s) {
+      var all = this.querySelectorAll('*');
+      var last = all[all.length - 1];
+      while (last.nextSibling) {
+        last = last.nextSibling;
+      }
+      var p = last.parentNode;
+      p.lastChild_ = undefined;
+      last.nextSibling_ = undefined;
+      originalWrite.call(this.impl, s);
     }
   });
 

--- a/src/wrappers/Document.js
+++ b/src/wrappers/Document.js
@@ -109,6 +109,7 @@
     'createTextNode',
     'elementFromPoint',
     'getElementById',
+    'write',
   ]);
 
   mixin(Document.prototype, GetElementsByInterface);

--- a/test/Document.js
+++ b/test/Document.js
@@ -4,7 +4,7 @@
  * license that can be found in the LICENSE file.
  */
 
-suite('Document', function() {
+htmlSuite('Document', function() {
 
   var wrap = ShadowDOMPolyfill.wrap;
 
@@ -188,4 +188,5 @@ suite('Document', function() {
     assert.equal(doc.elementFromPoint(5, 5), div);
   });
 
+  htmlTest('document-write.html');
 });

--- a/test/document-write.html
+++ b/test/document-write.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<script src="../node_modules/chai/chai.js"></script>
+<script src="../tools/test/htmltest.js"></script>
+<script src="../shadowdom.js"></script>
+<a></a><script>
+var assert = chai.assert;
+
+var a = document.querySelector('a');
+document.write('<b></b>');
+assert.equal(a.nextSibling.localName, 'script');
+assert.equal(a.nextSibling.nextSibling.localName, 'b');
+
+var all = document.querySelectorAll('*');
+var last = all[all.length - 1];
+assert.equal(last.localName, 'b');
+
+done();
+</script>

--- a/test/document-write.html
+++ b/test/document-write.html
@@ -4,11 +4,14 @@
 <script src="../shadowdom.js"></script>
 <a></a><script>
 var assert = chai.assert;
+var wrap = ShadowDOMPolyfill.wrap;
 
 var a = document.querySelector('a');
-document.write('<b></b>');
+document.write('<script><' + '/script>');
+wrap(document).write('<b></b>');
 assert.equal(a.nextSibling.localName, 'script');
-assert.equal(a.nextSibling.nextSibling.localName, 'b');
+assert.equal(a.nextSibling.nextSibling.localName, 'script');
+assert.equal(a.nextSibling.nextSibling.nextSibling.localName, 'b');
 
 var all = document.querySelectorAll('*');
 var last = all[all.length - 1];

--- a/test/index.html
+++ b/test/index.html
@@ -8,6 +8,7 @@ license that can be found in the LICENSE file.
 <link rel="stylesheet" href="../node_modules/mocha/mocha.css">
 <script src="../node_modules/chai/chai.js"></script>
 <script src="../node_modules/mocha/mocha.js"></script>
+<script src="../tools/test/mocha-htmltest.js"></script>
 <script src="../shadowdom.js"></script>
 <script src="test.main.js"></script>
 <div id="mocha"></div>


### PR DESCRIPTION
When we do a document.write we reset the lastChild_ and nextSibling_ pointers
so that next time we get lastChild or nextSibling we recompute them.

This also adds a dependency on tooltkitchen/tools to reuse the htmlSuite and
htmlTest.
