### PR TITLE
Make render invalidation smarter.

### DIFF
--- a/src/ShadowRenderer.js
+++ b/src/ShadowRenderer.js
@@ -508,7 +508,7 @@
     new ShadowRenderer(host).render();
   };
 
-  Node.prototype.invalidateShadowRenderer = function() {
+  Node.prototype.invalidateShadowRenderer = function(force) {
     // TODO: If this is in light DOM we only need to invalidate renderer if this
     // is a direct child of a ShadowRoot.
     // Maybe we should only associate renderers with direct child nodes of a
@@ -517,7 +517,12 @@
     if (!renderer)
       return false;
 
-    renderer.invalidate();
+    var p;
+    if (force || this.shadowRoot ||
+        (p = this.parentNode) && (p.shadowRoot || p instanceof ShadowRoot)) {
+      renderer.invalidate();
+    }
+
     return true;
   };
 

--- a/src/wrappers/Element.js
+++ b/src/wrappers/Element.js
@@ -33,9 +33,9 @@
       var newShadowRoot = new wrappers.ShadowRoot(this);
       shadowRootTable.set(this, newShadowRoot);
 
-      var renderer = scope.getRendererForHost(this);
+      scope.getRendererForHost(this);
 
-      this.invalidateShadowRenderer();
+      this.invalidateShadowRenderer(true);
 
       return newShadowRoot;
     },

--- a/src/wrappers/HTMLContentElement.js
+++ b/src/wrappers/HTMLContentElement.js
@@ -21,8 +21,13 @@
     },
     set select(value) {
       this.setAttribute('select', value);
-      this.invalidateShadowRenderer();
     },
+
+    setAttribute: function(n, v) {
+      HTMLElement.prototype.setAttribute.call(this, n, v);
+      if (String(n).toLowerCase() === 'select')
+        this.invalidateShadowRenderer(true);
+    }
 
     // getDistributedNodes is added in ShadowRenderer
 

--- a/src/wrappers/HTMLShadowElement.js
+++ b/src/wrappers/HTMLShadowElement.js
@@ -19,7 +19,12 @@
   mixin(HTMLShadowElement.prototype, {
     get olderShadowRoot() {
       return this.olderShadowRoot_;
-    }
+    },
+
+    invalidateShadowRenderer: function() {
+      HTMLElement.prototype.invalidateShadowRenderer.call(this, true);
+    },
+
     // TODO: attribute boolean resetStyleInheritance;
   });
 

--- a/src/wrappers/ShadowRoot.js
+++ b/src/wrappers/ShadowRoot.js
@@ -27,9 +27,6 @@
     scope.nextOlderShadowTreeTable.set(this, oldShadowRoot);
 
     shadowHostTable.set(this, hostWrapper);
-
-    // TODO: are we invalidating on both sides?
-    hostWrapper.invalidateShadowRenderer();
   }
   ShadowRoot.prototype = Object.create(DocumentFragment.prototype);
   mixin(ShadowRoot.prototype, {


### PR DESCRIPTION
We only need to invalidate if:
- This is a shadow root
- This is a shadow host
- We are changing the select property
- We are a direct child of a shadow root (this is a bit too agressive)
- We are a direct child of a shadow host
