### PR TITLE
Wrap compareDocumentPosition

### DIFF
--- a/src/wrappers/Document.js
+++ b/src/wrappers/Document.js
@@ -85,6 +85,7 @@
     window.HTMLHeadElement,
   ], [
     'appendChild',
+    'compareDocumentPosition',
     'getElementsByClassName',
     'getElementsByTagName',
     'getElementsByTagNameNS',

--- a/src/wrappers/Node.js
+++ b/src/wrappers/Node.js
@@ -137,6 +137,8 @@
   var originalInsertBefore = OriginalNode.prototype.insertBefore;
   var originalReplaceChild = OriginalNode.prototype.replaceChild;
   var originalRemoveChild = OriginalNode.prototype.removeChild;
+  var originalCompareDocumentPosition =
+      OriginalNode.prototype.compareDocumentPosition;
 
   Node.prototype = Object.create(EventTarget.prototype);
   mixin(Node.prototype, {
@@ -358,6 +360,12 @@
       if (!parentNode)
         return false;
       return this.contains(parentNode);
+    },
+
+    compareDocumentPosition: function(otherNode) {
+      // This only wraps, it therefore only operates on the composed DOM and not
+      // the logical DOM.
+      return originalCompareDocumentPosition.call(this.impl, unwrap(otherNode));
     }
   });
 

--- a/test/js/Node.js
+++ b/test/js/Node.js
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2013 The Toolkitchen Authors. All rights reserved.
+ * Use of this source code is goverened by a BSD-style
+ * license that can be found in the LICENSE file.
+ */
+
+suite('Node', function() {
+
+  var DOCUMENT_POSITION_DISCONNECTED = Node.DOCUMENT_POSITION_DISCONNECTED;
+  var DOCUMENT_POSITION_PRECEDING = Node.DOCUMENT_POSITION_PRECEDING;
+  var DOCUMENT_POSITION_FOLLOWING = Node.DOCUMENT_POSITION_FOLLOWING;
+  var DOCUMENT_POSITION_CONTAINS = Node.DOCUMENT_POSITION_CONTAINS;
+  var DOCUMENT_POSITION_CONTAINED_BY = Node.DOCUMENT_POSITION_CONTAINED_BY;
+  var DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC = Node.DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC;
+
+  test('compareDocumentPosition', function() {
+    var div = document.createElement('div');
+    div.innerHTML = '<a><b></b><c></c></a>';
+    var a = div.firstChild;
+    var b = a.firstChild;
+    var c = a.lastChild;
+
+    assert.equal(div.compareDocumentPosition(div), 0);
+    assert.equal(div.compareDocumentPosition(a),
+        DOCUMENT_POSITION_CONTAINED_BY | DOCUMENT_POSITION_FOLLOWING);
+    assert.equal(div.compareDocumentPosition(b),
+        DOCUMENT_POSITION_CONTAINED_BY | DOCUMENT_POSITION_FOLLOWING);
+    assert.equal(div.compareDocumentPosition(c),
+        DOCUMENT_POSITION_CONTAINED_BY | DOCUMENT_POSITION_FOLLOWING);
+
+    assert.equal(a.compareDocumentPosition(div),
+        DOCUMENT_POSITION_CONTAINS | DOCUMENT_POSITION_PRECEDING);
+    assert.equal(a.compareDocumentPosition(a), 0);
+    assert.equal(a.compareDocumentPosition(b),
+        DOCUMENT_POSITION_CONTAINED_BY | DOCUMENT_POSITION_FOLLOWING);
+    assert.equal(a.compareDocumentPosition(c),
+        DOCUMENT_POSITION_CONTAINED_BY | DOCUMENT_POSITION_FOLLOWING);
+
+    assert.equal(b.compareDocumentPosition(div),
+        DOCUMENT_POSITION_CONTAINS | DOCUMENT_POSITION_PRECEDING);
+    assert.equal(b.compareDocumentPosition(a),
+        DOCUMENT_POSITION_CONTAINS | DOCUMENT_POSITION_PRECEDING);
+    assert.equal(b.compareDocumentPosition(b), 0);
+    assert.equal(b.compareDocumentPosition(c),
+        DOCUMENT_POSITION_FOLLOWING);
+
+    assert.equal(c.compareDocumentPosition(div),
+        DOCUMENT_POSITION_CONTAINS | DOCUMENT_POSITION_PRECEDING);
+    assert.equal(c.compareDocumentPosition(a),
+        DOCUMENT_POSITION_CONTAINS | DOCUMENT_POSITION_PRECEDING);
+    assert.equal(c.compareDocumentPosition(b),
+        DOCUMENT_POSITION_PRECEDING);
+    assert.equal(c.compareDocumentPosition(c), 0);
+
+    // WebKit uses DOCUMENT_POSITION_IMPLEMENTATION_SPECIFIC.
+    assert.notEqual(document.compareDocumentPosition(div) &
+        DOCUMENT_POSITION_DISCONNECTED, 0)
+  });
+
+});

--- a/test/test.main.js
+++ b/test/test.main.js
@@ -59,6 +59,7 @@ var modules = [
   'HTMLShadowElement.js',
   'HTMLTemplateElement.js',
   'MutationObserver.js',
+  'Node.js',
   'ParentNodeInterface.js',
   'ShadowRoot.js',
   'Text.js',


### PR DESCRIPTION
This only wraps the native implementation so it only operates on the composed DOM.

In most cases `contains` is what we want anyway.

Fixes #134
