### PR TITLE
MutationObserver for IE. Second try.

### DIFF
--- a/src/wrappers/Node.js
+++ b/src/wrappers/Node.js
@@ -76,10 +76,10 @@
       assert(childWrapper.parentNode === wrapper);
       var nextSibling = childWrapper.nextSibling;
       var childNode = unwrap(childWrapper);
-      childWrapper.previousSibling_ = childWrapper.nextSibling_ = childWrapper.parentNode_ = null;
       var parentNode = childNode.parentNode;
       if (parentNode)
         originalRemoveChild.call(parentNode, childNode);
+      childWrapper.previousSibling_ = childWrapper.nextSibling_ = childWrapper.parentNode_ = null;
       childWrapper = nextSibling;
     }
     wrapper.firstChild_ = wrapper.lastChild_ = null;
@@ -207,21 +207,29 @@
 
       this.invalidateShadowRenderer();
 
-      if (this.firstChild === childWrapper)
-        this.firstChild_ = childWrapper.nextSibling;
-      if (this.lastChild === childWrapper)
-        this.lastChild_ = childWrapper.previousSibling;
-      if (childWrapper.previousSibling)
-        childWrapper.previousSibling.nextSibling_ = childWrapper.nextSibling;
-      if (childWrapper.nextSibling)
-        childWrapper.nextSibling.previousSibling_ = childWrapper.previousSibling;
-
-      childWrapper.previousSibling_ = childWrapper.nextSibling_ = childWrapper.parentNode_ = null;
+      // We need to remove the real node from the DOM before updating the
+      // pointers. This is so that that mutation event is dispatched before
+      // the pointers have changed.
+      var thisFirstChild = this.firstChild;
+      var thisLastChild = this.lastChild;
+      var childWrapperNextSibling = childWrapper.nextSibling;
+      var childWrapperPreviousSibling = childWrapper.previousSibling;
 
       var childNode = unwrap(childWrapper);
       var parentNode = childNode.parentNode;
       if (parentNode)
         originalRemoveChild.call(parentNode, childNode);
+
+      if (thisFirstChild === childWrapper)
+        this.firstChild_ = childWrapperNextSibling;
+      if (thisLastChild === childWrapper)
+        this.lastChild_ = childWrapperPreviousSibling;
+      if (childWrapperPreviousSibling)
+        childWrapperPreviousSibling.nextSibling_ = childWrapperNextSibling;
+      if (childWrapperNextSibling)
+        childWrapperNextSibling.previousSibling_ = childWrapperPreviousSibling;
+
+      childWrapper.previousSibling_ = childWrapper.nextSibling_ = childWrapper.parentNode_ = null;
 
       return childWrapper;
     },

--- a/test/js/MutationObserver.js
+++ b/test/js/MutationObserver.js
@@ -10,9 +10,18 @@ suite('MutationObserver', function() {
   var addedNodes = [], removedNodes = [];
   var div;
 
-  teardown(function() {
+  function newValue() {
+    return Date.now();
+  }
+
+  setup(function() {
     addedNodes = [];
     removedNodes = [];
+  });
+
+  teardown(function() {
+    addedNodes = undefined;
+    removedNodes = undefined;
     if (div) {
       if (div.parentNode)
         div.parentNode.removeChild(div);
@@ -42,12 +51,13 @@ suite('MutationObserver', function() {
       assert.equal(observer, mo);
       assert.equal(records[0].type, 'attributes');
       assert.equal(records[0].target, div);
+      mo.disconnect();
       done();
     });
     mo.observe(div, {
       attributes: true
     });
-    div.setAttribute('a', 'b');
+    div.setAttribute('a', newValue());
   });
 
   test('addedNodes', function(done) {
@@ -65,6 +75,7 @@ suite('MutationObserver', function() {
       assert.equal(addedNodes.length, 2);
       assert.equal(addedNodes[0], a);
       assert.equal(addedNodes[1], b);
+      mo.disconnect();
       done();
     });
     mo.observe(div, {
@@ -92,7 +103,7 @@ suite('MutationObserver', function() {
       assert.equal(addedNodes[0], c);
       assert.equal(records[0].previousSibling, a);
       assert.equal(records[0].nextSibling, b);
-
+      mo.disconnect();
       done();
     });
     div.innerHTML = '<a></a><b></b>';
@@ -126,6 +137,7 @@ suite('MutationObserver', function() {
       assert.equal(removedNodes.length, 2);
       assert.equal(removedNodes[0], a);
       assert.equal(removedNodes[1], b);
+      mo.disconnect();
       done();
     });
 
@@ -157,6 +169,7 @@ suite('MutationObserver', function() {
       assert.equal(removedNodes.length, 1);
       assert.equal(records[0].previousSibling, a);
       assert.equal(records[0].nextSibling, c);
+      mo.disconnect();
       done();
     });
 
@@ -191,7 +204,7 @@ suite('MutationObserver', function() {
       subtree: true
     });
 
-    document.body.setAttribute('a', 'b');
+    document.body.setAttribute('a', newValue());
   });
 
   test('observe document.body', function(done) {
@@ -212,7 +225,7 @@ suite('MutationObserver', function() {
       attributes: true
     });
 
-    document.body.setAttribute('a', 'b');
+    document.body.setAttribute('a', newValue());
   });
 
   test('observe document.head', function(done) {
@@ -233,7 +246,7 @@ suite('MutationObserver', function() {
       attributes: true
     });
 
-    document.head.setAttribute('a', 'b');
+    document.head.setAttribute('a', newValue());
   });
 
 });


### PR DESCRIPTION
This time the MutationObserver polyfill is added after the shadow dom polyfill
and the mutation observer only works with wrapped nodes. It still needs to be
aware of the wrappers since observe can be called with non wrapped nodes.
