### PR TITLE
Fix HTMLLegendElement for FF21

### DIFF
--- a/src/wrappers/override-constructors.js
+++ b/src/wrappers/override-constructors.js
@@ -7,10 +7,6 @@
 
   var isWrapperFor = scope.isWrapperFor;
 
-  Object.getOwnPropertyNames(scope.wrappers).forEach(function(name) {
-    window[name] = scope.wrappers[name]
-  });
-
   // This is a list of the elements we currently override the global constructor
   // for.
   var elements = {
@@ -98,6 +94,10 @@
   }
 
   Object.keys(elements).forEach(overrideConstructor);
+
+  Object.getOwnPropertyNames(scope.wrappers).forEach(function(name) {
+    window[name] = scope.wrappers[name]
+  });
 
   // Export for testing.
   scope.knownElements = elements;


### PR DESCRIPTION
In FF21 legend uses the old XPCOM binding which has issues that changing
window.HTLMElement changes any sub class that has HTMLElement in its prototype
chain. We therefore need to ensure that we do not override HTMLElement before
overriding HTMLLegendElement.

Fixes #149
