### PR TITLE
Fix Firefox 24 issue related to FocusEvent

### DIFF
--- a/src/wrappers/events.js
+++ b/src/wrappers/events.js
@@ -447,10 +447,17 @@
     GenericEvent.prototype = Object.create(SuperEvent.prototype);
     if (prototype)
       mixin(GenericEvent.prototype, prototype);
-    // Firefox does not support FocusEvent
-    // https://bugzilla.mozilla.org/show_bug.cgi?id=855741
-    if (OriginalEvent)
-      registerWrapper(OriginalEvent, GenericEvent, document.createEvent(name));
+    if (OriginalEvent) {
+      // IE does not support event constructors but FocusEvent can only be
+      // created using new FocusEvent in Firefox.
+      // https://bugzilla.mozilla.org/show_bug.cgi?id=882165
+      if (OriginalEvent.prototype['init' + name]) {
+        registerWrapper(OriginalEvent, GenericEvent,
+                        document.createEvent(name));
+      } else {
+        registerWrapper(OriginalEvent, GenericEvent, new OriginalEvent('temp'));
+      }
+    }
     return GenericEvent;
   }
 


### PR DESCRIPTION
FF24 does not support `document.createEvent('FocusEvent')` and to create a new
FocusEvent we need to use `new FocusEvent('x')`.

IE on the other hand does not support event constructors so we have to branch
here.

Fixes #159
