### PR TITLE
Disable defaultPrevented test in IE

### DIFF
--- a/test/js/events.js
+++ b/test/js/events.js
@@ -1173,7 +1173,11 @@ test('retarget order (multiple shadow roots)', function() {
 
     div.click();
     assert.equal(calls, 2);
-    assert.isTrue(event.defaultPrevented);
+
+    // defaultPrevented is broken in IE.
+    // https://connect.microsoft.com/IE/feedback/details/790389/event-defaultprevented-returns-false-after-preventdefault-was-called 
+    if (!/IE/.test(navigator.userAgent))
+      assert.isTrue(event.defaultPrevented);
   });
 
   test('event.path (bubbles)', function() {


### PR DESCRIPTION
defaultPrevented always returns false outside the event listener in IE.

https://connect.microsoft.com/IE/feedback/details/790389/event-defaultprevented-returns-false-after-preventdefault-was-called
