### PR TITLE
Implement wrapping of document.register

### DIFF
--- a/src/wrappers.js
+++ b/src/wrappers.js
@@ -9,6 +9,7 @@ var ShadowDOMPolyfill = {};
 
   var wrapperTable = new SideTable();
   var constructorTable = new SideTable();
+  var nativePrototypeTable = new SideTable();
   var wrappers = Object.create(null);
 
   function assert(b) {
@@ -152,7 +153,10 @@ var ShadowDOMPolyfill = {};
   function registerInternal(nativePrototype, wrapperConstructor, opt_instance) {
     var wrapperPrototype = wrapperConstructor.prototype;
     assert(constructorTable.get(nativePrototype) === undefined);
+
     constructorTable.set(nativePrototype, wrapperConstructor);
+    nativePrototypeTable.set(wrapperPrototype, nativePrototype);
+
     addForwardingProperties(nativePrototype, wrapperPrototype);
     if (opt_instance)
       registerInstanceProperties(wrapperPrototype, opt_instance);
@@ -312,11 +316,13 @@ var ShadowDOMPolyfill = {};
   }
 
   scope.assert = assert;
+  scope.constructorTable = constructorTable;
   scope.defineGetter = defineGetter;
   scope.defineWrapGetter = defineWrapGetter;
   scope.forwardMethodsToWrapper = forwardMethodsToWrapper;
   scope.isWrapperFor = isWrapperFor;
   scope.mixin = mixin;
+  scope.nativePrototypeTable = nativePrototypeTable;
   scope.registerObject = registerObject;
   scope.registerWrapper = register;
   scope.rewrap = rewrap;

--- a/test/js/Document.js
+++ b/test/js/Document.js
@@ -259,5 +259,56 @@ htmlSuite('Document', function() {
     assert.isTrue(document.contains(document.querySelector('html')));
   });
 
+  test('document.register', function() {
+    if (!document.register)
+      return;
+
+    var aPrototype = Object.create(HTMLElement.prototype);
+    aPrototype.getName = function() {
+      return 'a';
+    };
+
+    var A = document.register('x-a', {prototype: aPrototype});
+
+    var a1 = document.createElement('x-a');
+    assert.equal('x-a', a1.localName);
+    assert.equal(Object.getPrototypeOf(a1), aPrototype);
+    assert.instanceOf(a1, A);
+    assert.instanceOf(a1, HTMLElement);
+    assert.equal(a1.getName(), 'a');
+
+    var a2 = new A();
+    assert.equal('x-a', a2.localName);
+    assert.equal(Object.getPrototypeOf(a2), aPrototype);
+    assert.instanceOf(a2, A);
+    assert.instanceOf(a2, HTMLElement);
+    assert.equal(a2.getName(), 'a');
+
+    //////////////////////////////////////////////////////////////////////
+
+    var bPrototype = Object.create(A.prototype);
+    bPrototype.getName = function() {
+      return 'b';
+    };
+
+    var B = document.register('x-b', {prototype: bPrototype});
+
+    var b1 = document.createElement('x-b');
+    assert.equal('x-b', b1.localName);
+    assert.equal(Object.getPrototypeOf(b1), bPrototype);
+    assert.instanceOf(b1, B);
+    assert.instanceOf(b1, A);
+    assert.instanceOf(b1, HTMLElement);
+    assert.equal(b1.getName(), 'b');
+
+    var b2 = new B();
+    assert.equal('x-b', b2.localName);
+    assert.equal(Object.getPrototypeOf(b2), bPrototype);
+    assert.instanceOf(b2, B);
+    assert.instanceOf(b2, A);
+    assert.instanceOf(b2, HTMLElement);
+    assert.equal(b2.getName(), 'b');
+  });
+
   htmlTest('html/document-write.html');
 });


### PR DESCRIPTION
This works by creating a new object hierarchy that mimics the one passed into document.register. The returned function is a wrapper function which uses the passed in prototype as its prototype.

Fixes #190
