### PR TITLE
Fix issue with owner document when inserting across documents

### DIFF
--- a/src/wrappers/Document.js
+++ b/src/wrappers/Document.js
@@ -59,6 +59,11 @@
   var originalAdoptNode = document.adoptNode;
   var originalWrite = document.write;
 
+  function adoptNodeNoRemove(node, doc) {
+    originalAdoptNode.call(doc.impl, unwrap(node));
+    adoptSubtree(node, doc);
+  }
+
   function adoptSubtree(node, doc) {
     if (node.shadowRoot)
       doc.adoptNode(node.shadowRoot);
@@ -79,8 +84,7 @@
     adoptNode: function(node) {
       if (node.parentNode)
         node.parentNode.removeChild(node);
-      originalAdoptNode.call(this.impl, unwrap(node));
-      adoptSubtree(node, this);
+      adoptNodeNoRemove(node, this);
       return node;
     },
     elementFromPoint: function(x, y) {
@@ -284,7 +288,8 @@
     'hasFeature',
   ]);
 
-  scope.wrappers.Document = Document;
+  scope.adoptNodeNoRemove = adoptNodeNoRemove;
   scope.wrappers.DOMImplementation = DOMImplementation;
+  scope.wrappers.Document = Document;
 
 })(this.ShadowDOMPolyfill);

--- a/src/wrappers/Node.js
+++ b/src/wrappers/Node.js
@@ -60,15 +60,26 @@
     return nodes;
   }
 
+  function adoptIfNeeded(node, doc) {
+    if (doc !== node.ownerDocument)
+      scope.adoptNodeNoRemove(node, doc);
+  }
+
   function unwrapNodesForInsertion(owner, nodes) {
     var length = nodes.length;
 
-    if (length === 1)
-      return unwrap(nodes[0]);
+    if (length === 1) {
+      var node = nodes[0];
+      adoptIfNeeded(node, owner.ownerDocument);
+      return unwrap(node);
+    }
 
-    var df = unwrap(owner.ownerDocument.createDocumentFragment());
+    var ownerDoc = owner.ownerDocument;
+    var df = unwrap(ownerDoc.createDocumentFragment());
     for (var i = 0; i < length; i++) {
-      df.appendChild(unwrap(nodes[i]));
+      var node = nodes[i];
+      adoptIfNeeded(node, ownerDoc);
+      df.appendChild(unwrap(node));
     }
     return df;
   }

--- a/test/js/Node.js
+++ b/test/js/Node.js
@@ -6,6 +6,8 @@
 
 suite('Node', function() {
 
+  var wrap = ShadowDOMPolyfill.wrap;
+
   var DOCUMENT_POSITION_DISCONNECTED = Node.DOCUMENT_POSITION_DISCONNECTED;
   var DOCUMENT_POSITION_PRECEDING = Node.DOCUMENT_POSITION_PRECEDING;
   var DOCUMENT_POSITION_FOLLOWING = Node.DOCUMENT_POSITION_FOLLOWING;
@@ -57,4 +59,30 @@ suite('Node', function() {
         DOCUMENT_POSITION_DISCONNECTED, 0)
   });
 
+  test('ownerDocument with template and shadow root', function() {
+    var div = document.createElement('div');
+    div.innerHTML = '<template><span></span></template>';
+
+    var content1 = div.firstChild.content;
+    var host = content1.firstChild;
+
+    div.innerHTML = '<template>hello world</template>';
+    var content2 = div.firstChild.content;
+    var x = content2.firstChild;
+
+    var sr = host.createShadowRoot();
+    sr.appendChild(content2);
+
+    assert.equal(x.parentNode, sr);
+    assert.equal(x.ownerDocument, sr.ownerDocument);
+    assert.equal(sr.ownerDocument, host.ownerDocument);
+
+    var doc = wrap(document);
+    doc.body.appendChild(host);
+    assert.equal(host.ownerDocument, doc);
+    assert.equal(sr.ownerDocument, doc);
+    assert.equal(x.ownerDocument, doc);
+
+    doc.body.removeChild(host);
+  });
 });


### PR DESCRIPTION
Turns out that forcing a render does not solve the whole problem.

The main issue is that when we do an insert of a node from a different document we need to propagate the `ownerDocument` through the shadow roots.

Fixes issue #200
