### PR TITLE
ShadowDOM workarounds

### DIFF
--- a/src/wrappers/Node.js
+++ b/src/wrappers/Node.js
@@ -377,10 +377,19 @@
       // This only wraps, it therefore only operates on the composed DOM and not
       // the logical DOM.
       return originalCompareDocumentPosition.call(this.impl, unwrap(otherNode));
+    },
+
+    // TODO(jmesserly): this is a workaround for
+    // https://github.com/Polymer/ShadowDOM/issues/200
+    get ownerDocument() {
+      scope.renderAllPending();
+      return wrap(this.impl.ownerDocument);
     }
   });
 
-  defineWrapGetter(Node, 'ownerDocument');
+  // TODO(jmesserly): this is commented out to workaround:
+  // https://github.com/Polymer/ShadowDOM/issues/200
+  //defineWrapGetter(Node, 'ownerDocument');
 
   // We use a DocumentFragment as a base and then delete the properties of
   // DocumentFragment.prototype from the wrapper Node. Since delete makes

--- a/src/wrappers/events.js
+++ b/src/wrappers/events.js
@@ -596,6 +596,7 @@
       }
     },
     dispatchEvent: function(event) {
+      scope.renderAllPending();
       var target = getTargetToListenAt(this);
       return target.dispatchEvent_(unwrap(event));
     }


### PR DESCRIPTION
two workarounds we needed for the Dart version of TodoMVC to work. Issue #200 will likely be fixed soon, and I need to follow up about the dispatchEvent issue (it may only matter for our old rendertree tests).
