### PR TITLE
For html, head and body ignore the internal wrappers

### DIFF
--- a/src/wrappers/Document.js
+++ b/src/wrappers/Document.js
@@ -13,6 +13,7 @@
   var defineWrapGetter = scope.defineWrapGetter;
   var elementFromPoint = scope.elementFromPoint;
   var forwardMethodsToWrapper = scope.forwardMethodsToWrapper;
+  var ignoreInternalPointers = scope.ignoreInternalPointers;
   var matchesName = scope.matchesName;
   var mixin = scope.mixin;
   var registerWrapper = scope.registerWrapper;
@@ -34,6 +35,8 @@
   // overkill at this point.
   defineWrapGetter(Document, 'body');
   defineWrapGetter(Document, 'head');
+
+  ignoreInternalPointers(Document);
 
   // document cannot be overridden so we override a bunch of its methods
   // directly on the instance.

--- a/src/wrappers/Node.js
+++ b/src/wrappers/Node.js
@@ -403,6 +403,21 @@
   delete Node.prototype.querySelectorAll;
   Node.prototype = mixin(Object.create(EventTarget.prototype), Node.prototype);
 
+  var nodePointerNames = [
+    'parentNode',
+    'firstChild',
+    'lastChild',
+    'nextSibling',
+    'previousSibling',
+  ];
+
+  function ignoreInternalPointers(ctor) {
+    nodePointerNames.forEach(function(name) {
+      defineWrapGetter(ctor, name);
+    });
+  }
+
+  scope.ignoreInternalPointers = ignoreInternalPointers
   scope.wrappers.Node = Node;
 
 })(this.ShadowDOMPolyfill);

--- a/src/wrappers/override-constructors.js
+++ b/src/wrappers/override-constructors.js
@@ -5,6 +5,7 @@
 (function(scope) {
   'use strict';
 
+  var ignoreInternalPointers = scope.ignoreInternalPointers;
   var isWrapperFor = scope.isWrapperFor;
 
   // This is a list of the elements we currently override the global constructor
@@ -98,6 +99,10 @@
   Object.getOwnPropertyNames(scope.wrappers).forEach(function(name) {
     window[name] = scope.wrappers[name]
   });
+
+  ignoreInternalPointers(window.HTMLHtmlElement);
+  ignoreInternalPointers(window.HTMLHeadElement);
+  ignoreInternalPointers(window.HTMLBodyElement);
 
   // Export for testing.
   scope.knownElements = elements;

--- a/test/html/head-then-body.html
+++ b/test/html/head-then-body.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<script src="../../node_modules/chai/chai.js"></script>
+<script src="../../tools/test/htmltest.js"></script>
+<script src="../../shadowdom.js"></script>
+<head>
+<script>
+
+var assert = chai.assert;
+var wrap = ShadowDOMPolyfill.wrap;
+var doc = wrap(document);
+
+var div = document.createElement('div');
+document.documentElement.appendChild(div);
+div.parentNode.removeChild(div);
+
+</script>
+</head>
+<body></body>
+<script>
+
+doc.addEventListener('DOMContentLoaded', function(e) {
+  var body = document.querySelector('body');
+  debugger
+  assert.equal(body.localName, 'body');
+
+  done();
+});
+
+</script>

--- a/test/js/Document.js
+++ b/test/js/Document.js
@@ -448,4 +448,6 @@ htmlSuite('Document', function() {
   });
 
   htmlTest('html/document-write.html');
+
+  htmlTest('html/head-then-body.html');
 });


### PR DESCRIPTION
This is another workaround for jQuery.

The underlying problem is that wrappers are not updated as more nodes are added due to the parser.

Fixes #217
