### PR TITLE
Clean up invalidation code due to add or removal of children

### DIFF
--- a/src/ShadowRenderer.js
+++ b/src/ShadowRenderer.js
@@ -249,6 +249,11 @@
     this.associateNode(host);
   }
 
+  /**
+   * Returns existing shadow renderer for a host or creates it if it is needed.
+   * @params {!Element} host
+   * @return {!ShadowRenderer}
+   */
   function getRendererForHost(host) {
     var renderer = rendererForHostTable.get(host);
     if (!renderer) {
@@ -539,21 +544,15 @@
   };
 
   Node.prototype.invalidateShadowRenderer = function(force) {
-    // TODO: If this is in light DOM we only need to invalidate renderer if this
-    // is a direct child of a ShadowRoot.
-    // Maybe we should only associate renderers with direct child nodes of a
-    // shadow root (and all nodes in the shadow dom).
-    var renderer = shadowDOMRendererTable.get(this);
-    if (!renderer)
-      return false;
-
-    var p;
-    if (force || this.shadowRoot ||
-        (p = this.parentNode) && (p.shadowRoot || p instanceof ShadowRoot)) {
-      renderer.invalidate();
+    if (force || this.shadowRoot) {
+      var renderer = shadowDOMRendererTable.get(this);
+      if (renderer) {
+        renderer.invalidate();
+        return true;
+      }
     }
 
-    return true;
+    return false;
   };
 
   HTMLContentElement.prototype.getDistributedNodes = function() {

--- a/src/wrappers/Element.js
+++ b/src/wrappers/Element.js
@@ -32,13 +32,10 @@
   function invalidateRendererBasedOnAttribute(element, name) {
     // Only invalidate if parent node is a shadow host.
     var p = element.parentNode;
-    if (!p)
+    if (!p || !p.shadowRoot)
       return;
 
     var renderer = scope.getRendererForHost(p);
-    if (!renderer)
-      return;
-
     if (renderer.dependsOnAttribute(name))
       renderer.invalidate();
   }
@@ -52,9 +49,8 @@
       var newShadowRoot = new wrappers.ShadowRoot(this);
       shadowRootTable.set(this, newShadowRoot);
 
-      scope.getRendererForHost(this);
-
-      this.invalidateShadowRenderer(true);
+      var renderer = scope.getRendererForHost(this);
+      renderer.invalidate();
 
       return newShadowRoot;
     },

--- a/src/wrappers/HTMLElement.js
+++ b/src/wrappers/HTMLElement.js
@@ -119,10 +119,10 @@
       return getOuterHTML(this);
     },
     set outerHTML(value) {
-      if (!this.invalidateShadowRenderer()) {
+      var p = this.parentNode;
+      if (p) {
+        p.invalidateShadowRenderer();
         this.impl.outerHTML = value;
-      } else {
-        throw new Error('not implemented');
       }
     }
   });

--- a/src/wrappers/HTMLTemplateElement.js
+++ b/src/wrappers/HTMLTemplateElement.js
@@ -71,7 +71,6 @@
     },
     set innerHTML(value) {
       setInnerHTML(this.content, value);
-      this.invalidateShadowRenderer();
     }
 
     // TODO(arv): cloneNode needs to clone content.


### PR DESCRIPTION
We only need to invalidate the renderer if we are adding or removing a direct child of a host or a shadow root.

Other cases are handled by overriding `invalidateShadowRenderer`

This cleanup was part of trying to fix #216
