### PR TITLE
Use an internal pointer for ownerDocument

### DIFF
--- a/src/ShadowRenderer.js
+++ b/src/ShadowRenderer.js
@@ -249,6 +249,11 @@
     this.associateNode(host);
   }
 
+  /**
+   * Returns existing shadow renderer for a host or creates it if it is needed.
+   * @params {!Element} host
+   * @return {!ShadowRenderer}
+   */
   function getRendererForHost(host) {
     var renderer = rendererForHostTable.get(host);
     if (!renderer) {
@@ -539,21 +544,15 @@
   };
 
   Node.prototype.invalidateShadowRenderer = function(force) {
-    // TODO: If this is in light DOM we only need to invalidate renderer if this
-    // is a direct child of a ShadowRoot.
-    // Maybe we should only associate renderers with direct child nodes of a
-    // shadow root (and all nodes in the shadow dom).
-    var renderer = shadowDOMRendererTable.get(this);
-    if (!renderer)
-      return false;
-
-    var p;
-    if (force || this.shadowRoot ||
-        (p = this.parentNode) && (p.shadowRoot || p instanceof ShadowRoot)) {
-      renderer.invalidate();
+    if (force || this.shadowRoot) {
+      var renderer = shadowDOMRendererTable.get(this);
+      if (renderer) {
+        renderer.invalidate();
+        return true;
+      }
     }
 
-    return true;
+    return false;
   };
 
   HTMLContentElement.prototype.getDistributedNodes = function() {

--- a/src/wrappers/Document.js
+++ b/src/wrappers/Document.js
@@ -16,6 +16,7 @@
   var matchesName = scope.matchesName;
   var mixin = scope.mixin;
   var registerWrapper = scope.registerWrapper;
+  var setOwnerDocument = scope.setOwnerDocument;
   var unwrap = scope.unwrap;
   var wrap = scope.wrap;
   var wrapEventTargetMethods = scope.wrapEventTargetMethods;
@@ -85,6 +86,7 @@
     adoptNode: function(node) {
       if (node.parentNode)
         node.parentNode.removeChild(node);
+      setOwnerDocument(node, this);
       adoptNodeNoRemove(node, this);
       return node;
     },

--- a/src/wrappers/Element.js
+++ b/src/wrappers/Element.js
@@ -32,13 +32,10 @@
   function invalidateRendererBasedOnAttribute(element, name) {
     // Only invalidate if parent node is a shadow host.
     var p = element.parentNode;
-    if (!p)
+    if (!p || !p.shadowRoot)
       return;
 
     var renderer = scope.getRendererForHost(p);
-    if (!renderer)
-      return;
-
     if (renderer.dependsOnAttribute(name))
       renderer.invalidate();
   }
@@ -52,9 +49,8 @@
       var newShadowRoot = new wrappers.ShadowRoot(this);
       shadowRootTable.set(this, newShadowRoot);
 
-      scope.getRendererForHost(this);
-
-      this.invalidateShadowRenderer(true);
+      var renderer = scope.getRendererForHost(this);
+      renderer.invalidate();
 
       return newShadowRoot;
     },

--- a/src/wrappers/HTMLElement.js
+++ b/src/wrappers/HTMLElement.js
@@ -119,10 +119,10 @@
       return getOuterHTML(this);
     },
     set outerHTML(value) {
-      if (!this.invalidateShadowRenderer()) {
+      var p = this.parentNode;
+      if (p) {
+        p.invalidateShadowRenderer();
         this.impl.outerHTML = value;
-      } else {
-        throw new Error('not implemented');
       }
     }
   });

--- a/src/wrappers/HTMLTemplateElement.js
+++ b/src/wrappers/HTMLTemplateElement.js
@@ -71,7 +71,6 @@
     },
     set innerHTML(value) {
       setInnerHTML(this.content, value);
-      this.invalidateShadowRenderer();
     }
 
     // TODO(arv): cloneNode needs to clone content.

--- a/test/js/Document.js
+++ b/test/js/Document.js
@@ -186,6 +186,25 @@ htmlSuite('Document', function() {
     assert.equal(div.ownerDocument, doc2);
   });
 
+  test('adoptNode with child', function() {
+    var doc = wrap(document);
+    var doc2 = doc.implementation.createHTMLDocument('');
+    var div = doc2.createElement('div');
+    var a = div.appendChild(document.createElement('a'));
+    assert.equal(div.ownerDocument, doc2);
+    assert.equal(a.ownerDocument, doc2);
+
+    var div2 = document.adoptNode(div);
+    assert.equal(div, div2);
+    assert.equal(div.ownerDocument, doc);
+    assert.equal(a.ownerDocument, doc);
+
+    var div3 = doc2.adoptNode(div);
+    assert.equal(div, div3);
+    assert.equal(div.ownerDocument, doc2);
+    assert.equal(a.ownerDocument, doc2);
+  });
+
   test('adoptNode with shadowRoot', function() {
     var doc = wrap(document);
     var doc2 = doc.implementation.createHTMLDocument('');


### PR DESCRIPTION
This depends on #220

The earlier "solution" was to let `ownerDocument` be invalid when rendering was not valid. This worked quite for a while but eventually, due to usage of template document this became unsustainable. 

Now we use an internal pointer like we do for `parentNode` which we manually keep up to date.

Fixes #216
