### PR TITLE
Internal pointers

### DIFF
--- a/src/ShadowRenderer.js
+++ b/src/ShadowRenderer.js
@@ -562,6 +562,17 @@
     return getDistributedChildNodes(this);
   };
 
+  HTMLShadowElement.prototype.invalidateShadowRenderer =
+  HTMLContentElement.prototype.invalidateShadowRenderer = function(force) {
+    var renderer = shadowDOMRendererTable.get(this);
+    if (renderer) {
+      renderer.invalidate();
+      return true;
+    }
+
+    return false;
+  };
+
   scope.eventParentsTable = eventParentsTable;
   scope.getRendererForHost = getRendererForHost;
   scope.getShadowTrees = getShadowTrees;

--- a/src/wrappers/Document.js
+++ b/src/wrappers/Document.js
@@ -58,7 +58,6 @@
   ].forEach(wrapMethod);
 
   var originalAdoptNode = document.adoptNode;
-  var originalWrite = document.write;
 
   function adoptNodeNoRemove(node, doc) {
     originalAdoptNode.call(doc.impl, unwrap(node));
@@ -90,17 +89,6 @@
     },
     elementFromPoint: function(x, y) {
       return elementFromPoint(this, this, x, y);
-    },
-    write: function(s) {
-      var all = this.querySelectorAll('*');
-      var last = all[all.length - 1];
-      while (last.nextSibling) {
-        last = last.nextSibling;
-      }
-      var p = last.parentNode;
-      p.lastChild_ = undefined;
-      last.nextSibling_ = undefined;
-      originalWrite.call(this.impl, s);
     }
   });
 
@@ -223,7 +211,6 @@
     'createTextNode',
     'elementFromPoint',
     'getElementById',
-    'write',
   ]);
 
   mixin(Document.prototype, GetElementsByInterface);

--- a/src/wrappers/HTMLElement.js
+++ b/src/wrappers/HTMLElement.js
@@ -89,7 +89,7 @@
   function setInnerHTML(node, value, opt_tagName) {
     var tagName = opt_tagName || 'div';
     node.textContent = '';
-    var tempElement =unwrap(node.ownerDocument.createElement(tagName));
+    var tempElement = unwrap(node.ownerDocument.createElement(tagName));
     tempElement.innerHTML = value;
     var firstChild;
     while (firstChild = tempElement.firstChild) {
@@ -110,7 +110,10 @@
       return getInnerHTML(this);
     },
     set innerHTML(value) {
-      setInnerHTML(this, value, this.tagName);
+      if (this.invalidateShadowRenderer())
+        setInnerHTML(this, value, this.tagName);
+      else
+        this.impl.innerHTML = value;
     },
 
     get outerHTML() {

--- a/src/wrappers/HTMLShadowElement.js
+++ b/src/wrappers/HTMLShadowElement.js
@@ -17,7 +17,7 @@
   HTMLShadowElement.prototype = Object.create(HTMLElement.prototype);
   mixin(HTMLShadowElement.prototype, {
     invalidateShadowRenderer: function() {
-      HTMLElement.prototype.invalidateShadowRenderer.call(this, true);
+      return HTMLElement.prototype.invalidateShadowRenderer.call(this, true);
     },
 
     // TODO: attribute boolean resetStyleInheritance;

--- a/test/html/head-then-body.html
+++ b/test/html/head-then-body.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<script src="../../node_modules/chai/chai.js"></script>
+<script src="../../tools/test/htmltest.js"></script>
+<script src="../../shadowdom.js"></script>
+<head>
+<script>
+
+var assert = chai.assert;
+var wrap = ShadowDOMPolyfill.wrap;
+var doc = wrap(document);
+
+var div = document.createElement('div');
+document.documentElement.appendChild(div);
+div.parentNode.removeChild(div);
+
+</script>
+</head>
+<body></body>
+<script>
+
+doc.addEventListener('DOMContentLoaded', function(e) {
+  var body = document.querySelector('body');
+  assert.equal(body.localName, 'body');
+
+  done();
+});
+
+</script>

--- a/test/js/Document.js
+++ b/test/js/Document.js
@@ -448,4 +448,6 @@ htmlSuite('Document', function() {
   });
 
   htmlTest('html/document-write.html');
+
+  htmlTest('html/head-then-body.html');
 });

--- a/test/js/Node.js
+++ b/test/js/Node.js
@@ -85,4 +85,94 @@ suite('Node', function() {
 
     doc.body.removeChild(host);
   });
+
+  test('removeChild resets pointers', function() {
+    var host = document.createElement('div');
+    host.innerHTML = '<a></a>';
+    var a = host.firstChild;
+    var sr = host.createShadowRoot();
+
+    host.offsetHeight;
+
+    host.removeChild(a);
+
+    expectStructure(a, {});
+
+    var div = document.createElement('div');
+    div.appendChild(a);
+
+    expectStructure(div, {
+      firstChild: a,
+      lastChild: a
+    });
+
+    expectStructure(a, {
+      parentNode: div
+    });
+  });
+
+  test('replaceChild resets pointers', function() {
+    var host = document.createElement('div');
+    host.innerHTML = '<a></a>';
+    var a = host.firstChild;
+    var sr = host.createShadowRoot();
+
+    host.offsetHeight;
+
+    var b = document.createElement('b');
+
+    host.replaceChild(b, a);
+
+    expectStructure(a, {});
+
+    expectStructure(b, {
+      parentNode: host
+    });
+
+    var div = document.createElement('div');
+    div.appendChild(a);
+
+    expectStructure(div, {
+      firstChild: a,
+      lastChild: a
+    });
+
+    expectStructure(a, {
+      parentNode: div
+    });
+  });
+
+  test('appendChild resets pointers', function() {
+    var host1 = document.createElement('div');
+    host1.innerHTML = '<a></a>';
+    var a = host1.firstChild;
+    var sr1 = host1.createShadowRoot();
+
+    var host2 = document.createElement('div');
+    host2.innerHTML = '<b></b>';
+    var b = host2.firstChild;
+    var sr2 = host2.createShadowRoot();
+
+    host1.offsetHeight;
+    host2.offsetHeight;
+
+    host1.appendChild(b);
+
+    expectStructure(host1, {
+      firstChild: a,
+      lastChild: b
+    });
+
+    expectStructure(a, {
+      parentNode: host1,
+      nextSibling: b
+    });
+
+    expectStructure(b, {
+      parentNode: host1,
+      previousSibling: a
+    });
+
+    expectStructure(host2, {});
+  });
 });

--- a/test/js/paralleltrees.js
+++ b/test/js/paralleltrees.js
@@ -10,6 +10,17 @@ suite('Parallel Trees', function() {
   var unwrap = ShadowDOMPolyfill.unwrap;
   var visual = ShadowDOMPolyfill.visual;
 
+  var NodeInvalidate = Node.prototype.invalidateShadowRenderer;
+  setup(function() {
+    Node.prototype.invalidateShadowRenderer = function() {
+      return true;
+    };
+  });
+
+  teardown(function() {
+    Node.prototype.invalidateShadowRenderer = NodeInvalidate;
+  });
+
   suite('Visual', function() {
 
     test('removeAllChildNodes wrapper', function() {


### PR DESCRIPTION
This is a big change to how the internal pointers are used and when they are updated.

Previously, we always updated the internal pointers when a dom tree was mutated. Now we only update the pointers if the node would affect a shadow renderer or if it was part of render operation.

This means that we use the underlying native DOM nodes unless the node:
1. Is a shadow host
2. Is a shadow root
3. Is an HTMLContentElement
4. Is an HTMLShadowElement
5. The parent is a shadow host
6. The parent is a shadow root

Fixes #217

It also fixes #124 in a much cleaner way. The hack could be removed.
