### PR TITLE
Fix issues where we did not update the renderer after DOM changes

### DIFF
--- a/src/wrappers/HTMLShadowElement.js
+++ b/src/wrappers/HTMLShadowElement.js
@@ -16,10 +16,6 @@
   }
   HTMLShadowElement.prototype = Object.create(HTMLElement.prototype);
   mixin(HTMLShadowElement.prototype, {
-    invalidateShadowRenderer: function() {
-      return HTMLElement.prototype.invalidateShadowRenderer.call(this, true);
-    },
-
     // TODO: attribute boolean resetStyleInheritance;
   });
 

--- a/src/wrappers/events.js
+++ b/src/wrappers/events.js
@@ -176,8 +176,6 @@
       return true;
     if (a instanceof wrappers.ShadowRoot) {
       var host = scope.getHostForShadowRoot(a);
-      if (!host)
-        return false;
       return enclosedBy(rootOfNode(host), b);
     }
     return false;

--- a/test/js/HTMLContentElement.js
+++ b/test/js/HTMLContentElement.js
@@ -6,6 +6,8 @@
 
 suite('HTMLContentElement', function() {
 
+  var unwrap = ShadowDOMPolyfill.unwrap;
+
   test('select', function() {
     var el = document.createElement('content');
     assert.equal(el.select, null);
@@ -40,4 +42,98 @@ suite('HTMLContentElement', function() {
     assertArrayEqual(content.getDistributedNodes(), [b]);
   });
 
+  test('adding a new content element to a shadow tree', function() {
+    var host = document.createElement('div');
+    host.innerHTML = '<a></a><b></b>';
+    var a = host.firstChild;
+    var b = host.lastChild;
+
+    var sr = host.createShadowRoot();
+    sr.innerHTML = '<c></c>';
+    var c = sr.firstChild;
+
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, '<c></c>');
+
+    var content = document.createElement('content');
+    content.select = 'b';
+    c.appendChild(content);
+
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, '<c><b></b></c>');
+
+    c.removeChild(content);
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, '<c></c>');
+  });
+
+  test('restricting select further', function() {
+    var host = document.createElement('div');
+    host.innerHTML = '<a></a><b></b>';
+    var a = host.firstChild;
+    var b = host.lastChild;
+
+    var sr = host.createShadowRoot();
+    sr.innerHTML = '<c><content select="*"></content></c>';
+    var c = sr.firstChild;
+    var content = c.firstChild;
+
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, '<c><a></a><b></b></c>');
+
+    content.select = 'b';
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, '<c><b></b></c>');
+  });
+
+  test('Mutating content fallback', function() {
+    var host = document.createElement('div');
+    host.innerHTML = '<a></a>';
+    var a = host.firstChild;
+
+    var sr = host.createShadowRoot();
+    sr.innerHTML = '<content select="x"></content>';
+    var content = sr.firstChild;
+
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, '');
+
+    content.textContent = 'fallback';
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, 'fallback');
+
+    var b = content.appendChild(document.createElement('b'));
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, 'fallback<b></b>');
+
+    content.removeChild(b);
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, 'fallback');
+  });
+
+  test('Mutating content fallback 2', function() {
+    var host = document.createElement('div');
+    host.innerHTML = '<a></a>';
+    var a = host.firstChild;
+
+    var sr = host.createShadowRoot();
+    sr.innerHTML = '<b><content select="x"></content></b>';
+    var b = sr.firstChild;
+    var content = b.firstChild;
+
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, '<b></b>');
+
+    content.textContent = 'fallback';
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, '<b>fallback</b>');
+
+    var c = content.appendChild(document.createElement('c'));
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, '<b>fallback<c></c></b>');
+
+    content.removeChild(c);
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, '<b>fallback</b>');
+  });
 });

--- a/test/js/HTMLShadowElement.js
+++ b/test/js/HTMLShadowElement.js
@@ -32,4 +32,81 @@ suite('HTMLShadowElement', function() {
 
     assert.equal(unwrap(host).innerHTML, 'dabcf');
   });
+
+  test('adding a new shadow element to a shadow tree', function() {
+    var host = document.createElement('div');
+    host.innerHTML = '<a></a>';
+    var a = host.firstChild;
+
+    var sr = host.createShadowRoot();
+    sr.innerHTML = '<content></content>';
+
+    var sr2 = host.createShadowRoot();
+    sr2.innerHTML = '<b></b>';
+    var b = sr2.firstChild;
+
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, '<b></b>');
+
+    var shadow = document.createElement('shadow');
+    b.appendChild(shadow);
+
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, '<b><a></a></b>');
+
+    b.removeChild(shadow);
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, '<b></b>');
+  });
+
+  test('Mutating shadow fallback', function() {
+    var host = document.createElement('div');
+    host.innerHTML = '<a></a>';
+    var a = host.firstChild;
+
+    var sr = host.createShadowRoot();
+    sr.innerHTML = '<shadow></shadow>';
+    var shadow = sr.firstChild;
+
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, '');
+
+    shadow.textContent = 'fallback';
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, 'fallback');
+
+    var b = shadow.appendChild(document.createElement('b'));
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, 'fallback<b></b>');
+
+    shadow.removeChild(b);
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, 'fallback');
+  });
+
+  test('Mutating shadow fallback 2', function() {
+    var host = document.createElement('div');
+    host.innerHTML = '<a></a>';
+    var a = host.firstChild;
+
+    var sr = host.createShadowRoot();
+    sr.innerHTML = '<b><shadow></shadow></b>';
+    var b = sr.firstChild;
+    var shadow = b.firstChild;
+
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, '<b></b>');
+
+    shadow.textContent = 'fallback';
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, '<b>fallback</b>');
+
+    var c = shadow.appendChild(document.createElement('c'));
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, '<b>fallback<c></c></b>');
+
+    shadow.removeChild(c);
+    host.offsetHeight;
+    assert.equal(unwrap(host).innerHTML, '<b>fallback</b>');
+  });
 });

--- a/test/js/test.js
+++ b/test/js/test.js
@@ -417,18 +417,38 @@ suite('Shadow DOM', function() {
     assert.equal(count, 0);
     assert.equal(getVisualInnerHtml(host), '<b><d></d></b>');
 
-    var e = sr.appendChild(document.createElement('e'));
-    assert.equal(count, 1);
-    assert.equal(getVisualInnerHtml(host), '<b><d></d></b><e></e>');
+    b.appendChild(document.createElement('e'));
+    assert.equal(count, 0);
+    assert.equal(getVisualInnerHtml(host), '<b><d></d><e></e></b>');
 
-    e.appendChild(document.createElement('f'));
+    var f = sr.appendChild(document.createElement('f'));
     assert.equal(count, 1);
-    assert.equal(getVisualInnerHtml(host), '<b><d></d></b><e><f></f></e>');
+    assert.equal(getVisualInnerHtml(host), '<b><d></d><e></e></b><f></f>');
 
-    host.insertBefore(document.createElement('g'), text);
+    f.appendChild(document.createElement('g'));
+    assert.equal(count, 1);
+    assert.equal(getVisualInnerHtml(host),
+        '<b><d></d><e></e></b><f><g></g></f>');
+
+    host.insertBefore(document.createElement('h'), text);
     assert.equal(count, 2);
     assert.equal(getVisualInnerHtml(host),
-                 '<b><d></d></b><g></g><e><f></f></e>');
+                 '<b><d></d><e></e></b><h></h><f><g></g></f>');
+  });
+
+  test('issue-235', function() {
+    var host = document.createElement('div');
+    var sr = host.createShadowRoot();
+    sr.innerHTML = '<a><b></b></a>';
+    var a = sr.firstChild;
+    var b = a.firstChild;
+
+    assert.equal(getVisualInnerHtml(host), '<a><b></b></a>');
+
+    var c = document.createElement('c');
+    a.appendChild(c);
+
+    assert.equal(a.childNodes.length, 2);
   });
 
 });


### PR DESCRIPTION
- Changing content[select] to more restrictive needs to clean
  up non matching nodes (we clear the child nodes now)
- Changes to fallback content needs to invalidate
- Adding a content or shadow needs to invalidate

Fixes #226, #235
