### PR TITLE
Fix issue with ensureSameOwnerDocument when parent is a document

### DIFF
--- a/src/wrappers/Node.js
+++ b/src/wrappers/Node.js
@@ -61,7 +61,8 @@
   }
 
   function ensureSameOwnerDocument(parent, child) {
-    var ownerDoc = parent.ownerDocument;
+    var ownerDoc = parent.nodeType === Node.DOCUMENT_NODE ?
+        parent : parent.ownerDocument;
     if (ownerDoc !== child.ownerDocument)
       ownerDoc.adoptNode(child);
   }
@@ -278,7 +279,6 @@
         childWrapper.previousSibling_ = childWrapper.nextSibling_ =
             childWrapper.parentNode_ = undefined;
       } else {
-        ensureSameOwnerDocument(this, childWrapper);
         originalRemoveChild.call(this.impl, childNode);
       }
 

--- a/test/js/Node.js
+++ b/test/js/Node.js
@@ -86,6 +86,17 @@ suite('Node', function() {
     doc.body.removeChild(host);
   });
 
+  test('ownerDocument when appending to document', function() {
+    var doc1 = document.implementation.createHTMLDocument('');
+    var comment = doc1.createComment('');
+    doc1.appendChild(comment);
+    assert.equal(doc1, comment.ownerDocument);
+
+    var doc2 = document.implementation.createHTMLDocument('');
+    doc2.appendChild(comment);
+    assert.equal(doc2, comment.ownerDocument);
+  });
+
   test('removeChild resets pointers', function() {
     var host = document.createElement('div');
     host.innerHTML = '<a></a>';


### PR DESCRIPTION
This fixes the failing tests for IE.
