### PR TITLE
remove extra newline from enclosedBy in events.js

### DIFF
--- a/src/wrappers/events.js
+++ b/src/wrappers/events.js
@@ -179,7 +179,6 @@
       return enclosedBy(rootOfNode(host), b);
     }
     return false;
-
   }
 
   function isMutationEvent(type) {


### PR DESCRIPTION
Fixes a small style nit caught by @efortuna here:
https://codereview.chromium.org/23548014/diff/4001/pkg/shadow_dom/lib/shadow_dom.debug.js#newcode581
