### PR TITLE
Make sure we do not remove the shadow dom of nested hosts.

### DIFF
--- a/src/ShadowRenderer.js
+++ b/src/ShadowRenderer.js
@@ -266,6 +266,7 @@
    * the real DOM tree and make minimal changes as needed.
    */
   function RenderNode(node) {
+    this.skip = false;
     this.node = node;
     this.childNodes = [];
   }
@@ -278,6 +279,9 @@
     },
 
     sync: function(opt_added) {
+      if (this.skip)
+        return;
+
       var nodeWrapper = this.node;
       // plain array of RenderNodes
       var newChildren = this.childNodes;
@@ -390,6 +394,7 @@
 
       if (isShadowHost(node)) {
         var renderer = getRendererForHost(node);
+        renderNode.skip = !renderer.dirty;
         renderer.render(renderNode);
       } else {
         // We associate the parent of a content/shadow with the renderer

--- a/test/js/test.js
+++ b/test/js/test.js
@@ -451,4 +451,18 @@ suite('Shadow DOM', function() {
     assert.equal(a.childNodes.length, 2);
   });
 
+  test('nested shadow hosts (issue 245)', function() {
+    var outer = document.createElement('outer');
+    var inner = outer.appendChild(document.createElement('inner'));
+
+    // Inner first. Order matters.
+    var innerShadowRoot = inner.createShadowRoot();
+    innerShadowRoot.textContent = 'inner';
+
+    var outerShadowRoot = outer.createShadowRoot();
+    outerShadowRoot.innerHTML = '<content></content>outer';
+
+    assert.equal(getVisualInnerHtml(outer), '<inner>inner</inner>outer');
+  });
+
 });


### PR DESCRIPTION
When we rendered the outer tree and hit the inner host, its renderer was non dirty so the render tree was not created for that. When we later synced the trees it looked like the inner host should have no children.

The solution is to mark the render node as `skip` so that we do not recurse into it when we sync the trees.

Fixes #245
