### PR TITLE
No need to associate node with renderer just to remove stale child nodes

### DIFF
--- a/src/ShadowRenderer.js
+++ b/src/ShadowRenderer.js
@@ -397,10 +397,6 @@
         renderNode.skip = !renderer.dirty;
         renderer.render(renderNode);
       } else {
-        // We associate the parent of a content/shadow with the renderer
-        // because we may need to remove stale childNodes.
-        if (shadowDOMRendererTable.get(node))
-          this.associateNode(node);
         for (var child = node.firstChild; child; child = child.nextSibling) {
           this.renderNode(shadowRoot, renderNode, child, isNested);
         }


### PR DESCRIPTION
This one is no longer needed now that we sync the dom trees
