### PR TITLE
Change from using a WeakMap to use expando

### DIFF
--- a/src/ShadowRenderer.js
+++ b/src/ShadowRenderer.js
@@ -101,7 +101,6 @@
   var eventParentsTable = new WeakMap();
   var insertionParentTable = new WeakMap();
   var rendererForHostTable = new WeakMap();
-  var shadowDOMRendererTable = new WeakMap();
 
   function distributeChildToInsertionPoint(child, insertionPoint) {
     getDistributedChildNodes(insertionPoint).push(child);
@@ -554,7 +553,7 @@
     },
 
     associateNode: function(node) {
-      shadowDOMRendererTable.set(node, this);
+      node.impl.polymerShadowRenderer_ = this;
     }
   };
 
@@ -613,7 +612,7 @@
    * This gets called when a node was added or removed to it.
    */
   Node.prototype.invalidateShadowRenderer = function(force) {
-    var renderer = shadowDOMRendererTable.get(this);
+    var renderer = this.impl.polymerShadowRenderer_;
     if (renderer) {
       renderer.invalidate();
       return true;
@@ -623,7 +622,7 @@
   };
 
   HTMLContentElement.prototype.getDistributedNodes = function() {
-    var renderer = shadowDOMRendererTable.get(this);
+    var renderer = this.impl.polymerShadowRenderer_;
     if (renderer)
       renderer.render();
     return getDistributedChildNodes(this);
@@ -638,7 +637,7 @@
     var renderer;
     if (shadowRoot)
       renderer = getRendererForShadowRoot(shadowRoot);
-    shadowDOMRendererTable.set(this, renderer);
+    this.impl.polymerShadowRenderer_ = renderer;
     if (renderer)
       renderer.invalidate();
   };

--- a/src/wrappers/Element.js
+++ b/src/wrappers/Element.js
@@ -16,9 +16,7 @@
   var registerWrapper = scope.registerWrapper;
   var wrappers = scope.wrappers;
 
-  var shadowRootTable = new WeakMap();
   var OriginalElement = window.Element;
-
 
   var matchesName = oneOf(OriginalElement.prototype, [
     'matches',
@@ -47,7 +45,7 @@
   mixin(Element.prototype, {
     createShadowRoot: function() {
       var newShadowRoot = new wrappers.ShadowRoot(this);
-      shadowRootTable.set(this, newShadowRoot);
+      this.impl.polymerShadowRoot_ = newShadowRoot;
 
       var renderer = scope.getRendererForHost(this);
       renderer.invalidate();
@@ -56,7 +54,7 @@
     },
 
     get shadowRoot() {
-      return shadowRootTable.get(this) || null;
+      return this.impl.polymerShadowRoot_ || null;
     },
 
     setAttribute: function(name, value) {


### PR DESCRIPTION
Both the `shadowRoot` and renderer were backed by weak maps before and these get queried all the time. Changing them to expando for performance.
