### PR TITLE
Mute mutation events during rendering and template content extraction

### DIFF
--- a/src/ShadowRenderer.js
+++ b/src/ShadowRenderer.js
@@ -13,7 +13,9 @@
   var assert = scope.assert;
   var getHostForShadowRoot = scope.getHostForShadowRoot;
   var mixin = scope.mixin;
+  var muteMutationEvents = scope.muteMutationEvents;
   var oneOf = scope.oneOf;
+  var unmuteMutationEvents = scope.unmuteMutationEvents;
   var unwrap = scope.unwrap;
   var wrap = scope.wrap;
 
@@ -357,8 +359,11 @@
         this.renderNode(shadowRoot, renderNode, node, false);
       }
 
-      if (topMostRenderer)
+      if (topMostRenderer) {
+        muteMutationEvents();
         renderNode.sync();
+        unmuteMutationEvents();
+      }
 
       this.dirty = false;
     },

--- a/src/wrappers/HTMLTemplateElement.js
+++ b/src/wrappers/HTMLTemplateElement.js
@@ -8,8 +8,10 @@
   var HTMLElement = scope.wrappers.HTMLElement;
   var getInnerHTML = scope.getInnerHTML;
   var mixin = scope.mixin;
+  var muteMutationEvents = scope.muteMutationEvents;
   var registerWrapper = scope.registerWrapper;
   var setInnerHTML = scope.setInnerHTML;
+  var unmuteMutationEvents = scope.unmuteMutationEvents;
   var unwrap = scope.unwrap;
   var wrap = scope.wrap;
 
@@ -38,9 +40,11 @@
     var doc = getTemplateContentsOwner(templateElement.ownerDocument);
     var df = unwrap(doc.createDocumentFragment());
     var child;
+    muteMutationEvents();
     while (child = templateElement.firstChild) {
       df.appendChild(child);
     }
+    unmuteMutationEvents();
     return df;
   }
 

--- a/test/js/HTMLTemplateElement.js
+++ b/test/js/HTMLTemplateElement.js
@@ -78,4 +78,31 @@ suite('HTML Template Element', function() {
     });
   });
 
+  test('Mutation events', function() {
+    var div = document.createElement('div');
+    div.innerHTML = '<template> <a>b</a></template>';
+
+    var count = 0;
+    function handleEvent(e) {
+      count++;
+    }
+
+    div.addEventListener('DOMAttrModified', handleEvent, true);
+    div.addEventListener('DOMAttributeNameChanged', handleEvent, true);
+    div.addEventListener('DOMCharacterDataModified', handleEvent, true);
+    div.addEventListener('DOMElementNameChanged', handleEvent, true);
+    div.addEventListener('DOMNodeInserted', handleEvent, true);
+    div.addEventListener('DOMNodeInsertedIntoDocument', handleEvent, true);
+    div.addEventListener('DOMNodeRemoved', handleEvent, true);
+    div.addEventListener('DOMNodeRemovedFromDocument', handleEvent, true);
+    div.addEventListener('DOMSubtreeModified', handleEvent, true);
+
+    var template = div.firstChild;
+    assert.instanceOf(template.content, DocumentFragment);
+    assert.instanceOf(template.content.firstChild, Text);
+    assert.instanceOf(template.content.firstElementChild, HTMLAnchorElement);
+
+    assert.equal(count, 0);
+  });
+
 });

--- a/test/js/test.js
+++ b/test/js/test.js
@@ -465,4 +465,29 @@ suite('Shadow DOM', function() {
     assert.equal(getVisualInnerHtml(outer), '<inner>inner</inner>outer');
   });
 
+  test('no mutation events during rendering', function() {
+    var div = document.createElement('div');
+    div.innerHTML = '<a>b</a>';
+    var sr = div.createShadowRoot();
+    sr.innerHTML = 'c<content></content>d';
+
+    var count = 0;
+    function handleEvent(e) {
+      count++;
+    }
+
+    div.addEventListener('DOMAttrModified', handleEvent, true);
+    div.addEventListener('DOMAttributeNameChanged', handleEvent, true);
+    div.addEventListener('DOMCharacterDataModified', handleEvent, true);
+    div.addEventListener('DOMElementNameChanged', handleEvent, true);
+    div.addEventListener('DOMNodeInserted', handleEvent, true);
+    div.addEventListener('DOMNodeInsertedIntoDocument', handleEvent, true);
+    div.addEventListener('DOMNodeRemoved', handleEvent, true);
+    div.addEventListener('DOMNodeRemovedFromDocument', handleEvent, true);
+    div.addEventListener('DOMSubtreeModified', handleEvent, true);
+
+    assert.equal(getVisualInnerHtml(div), 'c<a>b</a>d');
+
+    assert.equal(count, 0);
+  });
 });


### PR DESCRIPTION
The extraction of template content was causing failures in browsers without native template element because it hit an iloop due to mutation events trying to create the wrapper.
