### PR TITLE
Add work around for X-Tag issue related to relatedTarget

### DIFF
--- a/src/wrappers/events.js
+++ b/src/wrappers/events.js
@@ -294,13 +294,19 @@
 
     if ('relatedTarget' in event) {
       var originalEvent = unwrap(event);
-      var relatedTarget = wrap(originalEvent.relatedTarget);
+      // X-Tag sets relatedTarget on a CustomEvent. If they do that there is no
+      // way to have relatedTarget return the adjusted target but worse is that
+      // the originalEvent might not have a relatedTarget so we hit an assert
+      // when we try to wrap it.
+      if (originalEvent.relatedTarget) {
+        var relatedTarget = wrap(originalEvent.relatedTarget);
 
-      var adjusted = adjustRelatedTarget(currentTarget, relatedTarget);
-      if (adjusted === target)
-        return true;
+        var adjusted = adjustRelatedTarget(currentTarget, relatedTarget);
+        if (adjusted === target)
+          return true;
 
-      relatedTargetTable.set(event, adjusted);
+        relatedTargetTable.set(event, adjusted);
+      }
     }
 
     eventPhaseTable.set(event, phase);

--- a/test/js/events.js
+++ b/test/js/events.js
@@ -1277,4 +1277,17 @@ test('retarget order (multiple shadow roots)', function() {
     text.dispatchEvent(new Event('x'));
   });
 
+  test('manual relatedTarget', function() {
+    var ce = new CustomEvent('x');
+    ce.relatedTarget = 42;
+    var count = 0;
+    document.addEventListener('x', function f(e) {
+      count++;
+      assert.equal(e.relatedTarget, 42);
+      document.removeEventListener('x', f);
+    });
+    document.dispatchEvent(ce);
+    assert.equal(count, 1);
+  });
+
 });


### PR DESCRIPTION
X-Tag sets relatedTarget on a CustomEvent. If they do that there is no
way to have relatedTarget return the adjusted target but worse is that
the originalEvent might not have a relatedTarget so we hit an assert
when we try to wrap it.

Fixes #268
