### PR TITLE
Explicitly read/write ShadowDOMPolyfill on window

### DIFF
--- a/src/ShadowRenderer.js
+++ b/src/ShadowRenderer.js
@@ -659,4 +659,4 @@
     remove: remove,
   };
 
-})(this.ShadowDOMPolyfill);
+})(window.ShadowDOMPolyfill);

--- a/src/querySelector.js
+++ b/src/querySelector.js
@@ -70,4 +70,4 @@
   scope.GetElementsByInterface = GetElementsByInterface;
   scope.SelectorsInterface = SelectorsInterface;
 
-})(this.ShadowDOMPolyfill);
+})(window.ShadowDOMPolyfill);

--- a/src/wrappers.js
+++ b/src/wrappers.js
@@ -2,7 +2,7 @@
 // Use of this source code is goverened by a BSD-style
 // license that can be found in the LICENSE file.
 
-var ShadowDOMPolyfill = {};
+window.ShadowDOMPolyfill = {};
 
 (function(scope) {
   'use strict';
@@ -370,4 +370,4 @@ var ShadowDOMPolyfill = {};
   scope.wrapIfNeeded = wrapIfNeeded;
   scope.wrappers = wrappers;
 
-})(this.ShadowDOMPolyfill);
+})(window.ShadowDOMPolyfill);

--- a/src/wrappers/CanvasRenderingContext2D.js
+++ b/src/wrappers/CanvasRenderingContext2D.js
@@ -35,4 +35,4 @@
   registerWrapper(OriginalCanvasRenderingContext2D, CanvasRenderingContext2D);
 
   scope.wrappers.CanvasRenderingContext2D = CanvasRenderingContext2D;
-})(this.ShadowDOMPolyfill);
+})(window.ShadowDOMPolyfill);

--- a/src/wrappers/CharacterData.js
+++ b/src/wrappers/CharacterData.js
@@ -31,4 +31,4 @@
                   document.createTextNode(''));
 
   scope.wrappers.CharacterData = CharacterData;
-})(this.ShadowDOMPolyfill);
+})(window.ShadowDOMPolyfill);

--- a/src/wrappers/Document.js
+++ b/src/wrappers/Document.js
@@ -281,4 +281,4 @@
   scope.wrappers.DOMImplementation = DOMImplementation;
   scope.wrappers.Document = Document;
 
-})(this.ShadowDOMPolyfill);
+})(window.ShadowDOMPolyfill);

--- a/src/wrappers/Element.js
+++ b/src/wrappers/Element.js
@@ -114,4 +114,4 @@
   // that reflect attributes.
   scope.matchesName = matchesName;
   scope.wrappers.Element = Element;
-})(this.ShadowDOMPolyfill);
+})(window.ShadowDOMPolyfill);

--- a/src/wrappers/HTMLCanvasElement.js
+++ b/src/wrappers/HTMLCanvasElement.js
@@ -28,4 +28,4 @@
                   document.createElement('canvas'));
 
   scope.wrappers.HTMLCanvasElement = HTMLCanvasElement;
-})(this.ShadowDOMPolyfill);
+})(window.ShadowDOMPolyfill);

--- a/src/wrappers/HTMLContentElement.js
+++ b/src/wrappers/HTMLContentElement.js
@@ -38,4 +38,4 @@
     registerWrapper(OriginalHTMLContentElement, HTMLContentElement);
 
   scope.wrappers.HTMLContentElement = HTMLContentElement;
-})(this.ShadowDOMPolyfill);
+})(window.ShadowDOMPolyfill);

--- a/src/wrappers/HTMLElement.js
+++ b/src/wrappers/HTMLElement.js
@@ -197,4 +197,4 @@
   // TODO: Find a better way to share these two with WrapperShadowRoot.
   scope.getInnerHTML = getInnerHTML;
   scope.setInnerHTML = setInnerHTML
-})(this.ShadowDOMPolyfill);
+})(window.ShadowDOMPolyfill);

--- a/src/wrappers/HTMLImageElement.js
+++ b/src/wrappers/HTMLImageElement.js
@@ -39,4 +39,4 @@
 
   scope.wrappers.HTMLImageElement = HTMLImageElement;
   scope.wrappers.Image = Image;
-})(this.ShadowDOMPolyfill);
+})(window.ShadowDOMPolyfill);

--- a/src/wrappers/HTMLShadowElement.js
+++ b/src/wrappers/HTMLShadowElement.js
@@ -23,4 +23,4 @@
     registerWrapper(OriginalHTMLShadowElement, HTMLShadowElement);
 
   scope.wrappers.HTMLShadowElement = HTMLShadowElement;
-})(this.ShadowDOMPolyfill);
+})(window.ShadowDOMPolyfill);

--- a/src/wrappers/HTMLTemplateElement.js
+++ b/src/wrappers/HTMLTemplateElement.js
@@ -81,4 +81,4 @@
     registerWrapper(OriginalHTMLTemplateElement, HTMLTemplateElement);
 
   scope.wrappers.HTMLTemplateElement = HTMLTemplateElement;
-})(this.ShadowDOMPolyfill);
+})(window.ShadowDOMPolyfill);

--- a/src/wrappers/HTMLUnknownElement.js
+++ b/src/wrappers/HTMLUnknownElement.js
@@ -28,4 +28,4 @@
   HTMLUnknownElement.prototype = Object.create(HTMLElement.prototype);
   registerWrapper(OriginalHTMLUnknownElement, HTMLUnknownElement);
   scope.wrappers.HTMLUnknownElement = HTMLUnknownElement;
-})(this.ShadowDOMPolyfill);
+})(window.ShadowDOMPolyfill);

--- a/src/wrappers/MutationObserver.js
+++ b/src/wrappers/MutationObserver.js
@@ -84,4 +84,4 @@
   scope.wrappers.MutationObserver = MutationObserver;
   scope.wrappers.MutationRecord = MutationRecord;
 
-})(this.ShadowDOMPolyfill);
+})(window.ShadowDOMPolyfill);

--- a/src/wrappers/Node.js
+++ b/src/wrappers/Node.js
@@ -494,4 +494,4 @@
 
   scope.wrappers.Node = Node;
 
-})(this.ShadowDOMPolyfill);
+})(window.ShadowDOMPolyfill);

--- a/src/wrappers/NodeList.js
+++ b/src/wrappers/NodeList.js
@@ -43,4 +43,4 @@
   scope.addWrapNodeListMethod = addWrapNodeListMethod;
   scope.wrapNodeList = wrapNodeList;
 
-})(this.ShadowDOMPolyfill);
+})(window.ShadowDOMPolyfill);

--- a/src/wrappers/Range.js
+++ b/src/wrappers/Range.js
@@ -89,4 +89,4 @@
 
   scope.wrappers.Range = Range;
 
-})(this.ShadowDOMPolyfill);
+})(window.ShadowDOMPolyfill);

--- a/src/wrappers/ShadowRoot.js
+++ b/src/wrappers/ShadowRoot.js
@@ -60,4 +60,4 @@
   scope.getHostForShadowRoot = function(node) {
     return shadowHostTable.get(node);
   };
-})(this.ShadowDOMPolyfill);
+})(window.ShadowDOMPolyfill);

--- a/src/wrappers/WebGLRenderingContext.js
+++ b/src/wrappers/WebGLRenderingContext.js
@@ -39,4 +39,4 @@
   registerWrapper(OriginalWebGLRenderingContext, WebGLRenderingContext);
 
   scope.wrappers.WebGLRenderingContext = WebGLRenderingContext;
-})(this.ShadowDOMPolyfill);
+})(window.ShadowDOMPolyfill);

--- a/src/wrappers/Window.js
+++ b/src/wrappers/Window.js
@@ -46,4 +46,4 @@
 
   scope.wrappers.Window = Window;
 
-})(this.ShadowDOMPolyfill);
+})(window.ShadowDOMPolyfill);

--- a/src/wrappers/elements-with-form-property.js
+++ b/src/wrappers/elements-with-form-property.js
@@ -51,4 +51,4 @@
 
   elementsWithFormProperty.forEach(createWrapperConstructor);
 
-})(this.ShadowDOMPolyfill);
+})(window.ShadowDOMPolyfill);

--- a/src/wrappers/events.js
+++ b/src/wrappers/events.js
@@ -746,4 +746,4 @@
   scope.wrappers.MutationEvent = MutationEvent;
   scope.wrappers.UIEvent = UIEvent;
 
-})(this.ShadowDOMPolyfill);
+})(window.ShadowDOMPolyfill);

--- a/src/wrappers/generic.js
+++ b/src/wrappers/generic.js
@@ -23,4 +23,4 @@
   scope.wrappers.DocumentFragment = DocumentFragment;
   scope.wrappers.Text = Text;
 
-})(this.ShadowDOMPolyfill);
+})(window.ShadowDOMPolyfill);

--- a/src/wrappers/node-interfaces.js
+++ b/src/wrappers/node-interfaces.js
@@ -66,4 +66,4 @@
   scope.ChildNodeInterface = ChildNodeInterface;
   scope.ParentNodeInterface = ParentNodeInterface;
 
-})(this.ShadowDOMPolyfill);
+})(window.ShadowDOMPolyfill);

--- a/src/wrappers/override-constructors.js
+++ b/src/wrappers/override-constructors.js
@@ -100,4 +100,4 @@
   // Export for testing.
   scope.knownElements = elements;
 
-})(this.ShadowDOMPolyfill);
+})(window.ShadowDOMPolyfill);


### PR DESCRIPTION
Would be good to adopt a policy of always explicitly attaching/reading from global scope to make it nice and clear where the data is coming from… and to ensure the code executes correctly when `this` or the global scope might have been altered.
