### PR TITLE
Fix issue with canvas parameters

### DIFF
--- a/src/wrappers/CanvasRenderingContext2D.js
+++ b/src/wrappers/CanvasRenderingContext2D.js
@@ -8,6 +8,7 @@
   var mixin = scope.mixin;
   var registerWrapper = scope.registerWrapper;
   var unwrap = scope.unwrap;
+  var unwrapIfNeeded = scope.unwrapIfNeeded;
   var wrap = scope.wrap;
 
   var OriginalCanvasRenderingContext2D = window.CanvasRenderingContext2D;
@@ -22,7 +23,7 @@
     },
 
     drawImage: function() {
-      arguments[0] = unwrap(arguments[0]);
+      arguments[0] = unwrapIfNeeded(arguments[0]);
       this.impl.drawImage.apply(this.impl, arguments);
     },
 

--- a/src/wrappers/WebGLRenderingContext.js
+++ b/src/wrappers/WebGLRenderingContext.js
@@ -7,7 +7,7 @@
 
   var mixin = scope.mixin;
   var registerWrapper = scope.registerWrapper;
-  var unwrap = scope.unwrap;
+  var unwrapIfNeeded = scope.unwrapIfNeeded;
   var wrap = scope.wrap;
 
   var OriginalWebGLRenderingContext = window.WebGLRenderingContext;
@@ -26,12 +26,12 @@
     },
 
     texImage2D: function() {
-      arguments[5] = unwrap(arguments[5]);
+      arguments[5] = unwrapIfNeeded(arguments[5]);
       this.impl.texImage2D.apply(this.impl, arguments);
     },
 
     texSubImage2D: function() {
-      arguments[6] = unwrap(arguments[6]);
+      arguments[6] = unwrapIfNeeded(arguments[6]);
       this.impl.texSubImage2D.apply(this.impl, arguments);
     }
   });

--- a/test/js/HTMLCanvasElement.js
+++ b/test/js/HTMLCanvasElement.js
@@ -93,11 +93,21 @@ suite('HTMLCanvasElement', function() {
       return;
     }
 
+    var imageData = document.createElement('canvas').getContext('2d').
+        createImageData(16, 16);
+    var arrayBufferView = new Uint8Array(16 * 16 * 4);
+
     var img = document.createElement('img');
     img.onload = function() {
       var texture = gl.createTexture();
       gl.bindTexture(gl.TEXTURE_2D, texture);
       gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, img);
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE,
+                    imageData);
+      gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA,
+                    16, 16, 0,
+                    gl.RGBA, gl.UNSIGNED_BYTE, arrayBufferView);
+
       done();
     };
     img.src = iconUrl;
@@ -118,11 +128,16 @@ suite('HTMLCanvasElement', function() {
       return;
     }
 
+    var arrayBufferView = new Uint8Array(16 * 16 * 4);
+
     var img = document.createElement('img');
     img.onload = function() {
       var texture = gl.createTexture();
       gl.bindTexture(gl.TEXTURE_2D, texture);
       gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGBA, gl.UNSIGNED_BYTE, img);
+      gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0,
+          16, 16,
+          gl.RGBA, gl.UNSIGNED_BYTE, arrayBufferView);
       done();
     };
     img.src = iconUrl;


### PR DESCRIPTION
texImage2D, texSubImage2D and drawImage are overloaded to accept a lot of different combinations. Update the wrappers to correctly handle all the current overloads.

Fixes #283
