### PR TITLE
wrappers.js: must set `hasEval` to false if Function constructor threw an exception

### DIFF
--- a/src/wrappers.js
+++ b/src/wrappers.js
@@ -21,6 +21,7 @@ var ShadowDOMPolyfill = {};
       var f = new Function('', 'return true;');
       hasEval = f();
     } catch (ex) {
+      return false;
     }
   }
 


### PR DESCRIPTION
If the `securityPolicy` test fails but `new Function()` throws an exception, we must conclude `hasEval` should be false.
