### PR TITLE
Preserve 'extends' when the ShadowDOM polyfill patches document.register

### DIFF
--- a/src/wrappers/Document.js
+++ b/src/wrappers/Document.js
@@ -150,12 +150,19 @@
         };
       });
 
-      var nativeConstructor = originalRegister.call(unwrap(this), tagName,
-          {prototype: newPrototype});
+      var p = {prototype: newPrototype};
+      if (object.extends)
+        p.extends = object.extends;
+      var nativeConstructor = originalRegister.call(unwrap(this), tagName, p);
 
       function GeneratedWrapper(node) {
-        if (!node)
-          return document.createElement(tagName);
+        if (!node) {
+          if (object.extends) {
+            return document.createElement(object.extends, tagName);
+          } else {
+            return document.createElement(tagName);
+          }
+        }
         this.impl = node;
       }
       GeneratedWrapper.prototype = prototype;

--- a/test/js/Document.js
+++ b/test/js/Document.js
@@ -310,6 +310,35 @@ htmlSuite('Document', function() {
     assert.equal(b2.getName(), 'b');
   });
 
+  test('document.register type extension', function() {
+    if (!document.register)
+      return;
+
+    var aPrototype = Object.create(HTMLSpanElement.prototype);
+    aPrototype.getName = function() {
+      return 'a';
+    };
+
+    var A = document.register('x-a-span',
+      {prototype: aPrototype, extends: 'span'});
+
+    var a1 = document.createElement('span', 'x-a-span');
+    assert.equal('span', a1.localName);
+    assert.equal('<span is="x-a-span"></span>', a1.outerHTML);
+    assert.equal(Object.getPrototypeOf(a1), aPrototype);
+    assert.instanceOf(a1, A);
+    assert.instanceOf(a1, HTMLSpanElement);
+    assert.equal(a1.getName(), 'a');
+
+    var a2 = new A();
+    assert.equal('span', a2.localName);
+    assert.equal('<span is="x-a-span"></span>', a2.outerHTML);
+    assert.equal(Object.getPrototypeOf(a2), aPrototype);
+    assert.instanceOf(a2, A);
+    assert.instanceOf(a2, HTMLSpanElement);
+    assert.equal(a2.getName(), 'a');
+  });
+
   test('document.register deeper', function() {
     if (!document.register)
       return;


### PR DESCRIPTION
I noticed this bug only when using the shadow-dom polyfill in combination with the native document.register. Here is a sample repro example:

``` html
<!DOCTYPE html>
<html><body>
  <script src="ShadowDOM/shadowdom.js"></script>

  <x-b></x-b> <span is="x-c"></span>

  <script>
    var bp = Object.create(HTMLElement.prototype);
    bp.createdCallback = function() { console.log("b created"); };
    var B = document.register('x-b', { prototype: bp });

    var cp = Object.create(HTMLSpanElement.prototype);
    cp.createdCallback = function() { console.log("c created"); };
    var C = document.register('x-c', { prototype: cp, extends: 'span' });
  </script>
```

You'd expect to see: `b created` and `c created`, but only `b created` is printed.
