### PR TITLE
Fix issue with missing instance properties on canvas context classes

### DIFF
--- a/src/wrappers/CanvasRenderingContext2D.js
+++ b/src/wrappers/CanvasRenderingContext2D.js
@@ -33,7 +33,8 @@
     }
   });
 
-  registerWrapper(OriginalCanvasRenderingContext2D, CanvasRenderingContext2D);
+  registerWrapper(OriginalCanvasRenderingContext2D, CanvasRenderingContext2D,
+                  document.createElement('canvas').getContext('2d'));
 
   scope.wrappers.CanvasRenderingContext2D = CanvasRenderingContext2D;
 })(window.ShadowDOMPolyfill);

--- a/src/wrappers/WebGLRenderingContext.js
+++ b/src/wrappers/WebGLRenderingContext.js
@@ -36,7 +36,15 @@
     }
   });
 
-  registerWrapper(OriginalWebGLRenderingContext, WebGLRenderingContext);
+  // Blink/WebKit has broken DOM bindings. Usually we would create an instance
+  // of the object and pass it into registerWrapper as a "blueprint" but
+  // creating WebGL contexts is expensive and might fail so we use a dummy
+  // object with dummy instance properties for these broken browsers.
+  var instanceProperties = /WebKit/.test(navigator.userAgent) ?
+      {drawingBufferHeight: null, drawingBufferWidth: null} : {};
+
+  registerWrapper(OriginalWebGLRenderingContext, WebGLRenderingContext,
+      instanceProperties);
 
   scope.wrappers.WebGLRenderingContext = WebGLRenderingContext;
 })(window.ShadowDOMPolyfill);

--- a/test/js/HTMLCanvasElement.js
+++ b/test/js/HTMLCanvasElement.js
@@ -41,6 +41,27 @@ suite('HTMLCanvasElement', function() {
       assert.equal(context.canvas, canvas);
   });
 
+  test('context instance properties', function() {
+    var canvas = document.createElement('canvas');
+    var context = canvas.getContext('2d');
+
+    assert.isString(context.fillStyle);
+    assert.isString(context.strokeStyle);
+    assert.isString(context.textBaseline);
+    assert.isString(context.textAlign);
+    assert.isString(context.font);
+    assert.isNumber(context.lineDashOffset);
+    assert.isString(context.shadowColor);
+    assert.isNumber(context.shadowBlur);
+    assert.isNumber(context.shadowOffsetY);
+    assert.isNumber(context.shadowOffsetX);
+    assert.isNumber(context.miterLimit);
+    assert.isString(context.lineJoin);
+    assert.isString(context.lineCap);
+    assert.isNumber(context.lineWidth);
+    assert.isNumber(context.globalAlpha);
+  });
+
   test('2d drawImage using new Image', function(done) {
     var canvas = document.createElement('canvas');
     var context = canvas.getContext('2d');
@@ -111,6 +132,24 @@ suite('HTMLCanvasElement', function() {
       done();
     };
     img.src = iconUrl;
+  });
+
+  test('WebGL context instance properties', function() {
+    var canvas = document.createElement('canvas');
+    var gl = null;
+    // Firefox throws exception if graphics card is not supported
+    try {
+      gl = canvas.getContext('webgl');
+    } catch (ex) {
+    }
+    // IE10 does not have WebGL.
+    // Chrome returns null if the graphics card is not supported
+    if (!gl) {
+      return;
+    }
+
+    assert.isNumber(gl.drawingBufferHeight);
+    assert.isNumber(gl.drawingBufferWidth);
   });
 
   test('WebGL texSubImage2D', function(done) {


### PR DESCRIPTION
Since Blink/WebKit uses magic instance properties instead of accessors we need to pass in an object listing
the instance properties.
