### PR TITLE
Don't use native cloneNode

### DIFF
--- a/src/wrappers/Node.js
+++ b/src/wrappers/Node.js
@@ -477,9 +477,6 @@
     },
 
     cloneNode: function(deep) {
-      if (!this.invalidateShadowRenderer())
-        return wrap(this.impl.cloneNode(deep));
-
       var clone = wrap(this.impl.cloneNode(false));
       if (deep) {
         for (var child = this.firstChild; child; child = child.nextSibling) {

--- a/test/js/wrappers.js
+++ b/test/js/wrappers.js
@@ -7,6 +7,7 @@
 suite('Wrapper creation', function() {
 
   var wrap = ShadowDOMPolyfill.wrap;
+  var unwrap = ShadowDOMPolyfill.unwrap;
   var knownElements = ShadowDOMPolyfill.knownElements;
 
   test('Br element wrapper', function() {
@@ -26,81 +27,6 @@ suite('Wrapper creation', function() {
       assert.instanceOf(element, constructor);
       assert.equal(Object.getPrototypeOf(element), constructor.prototype);
     });
-  });
-
-  test('cloneNode(false)', function() {
-    var doc = wrap(document);
-    var a = document.createElement('a');
-    a.href = 'http://domain.com/';
-    a.textContent = 'text';
-    var textNode = a.firstChild;
-
-    var aClone = a.cloneNode(false);
-
-    assert.equal(aClone.tagName, 'A');
-    assert.equal(aClone.href, 'http://domain.com/');
-    expectStructure(aClone, {});
-  });
-
-  test('cloneNode(true)', function() {
-    var doc = wrap(document);
-    var a = document.createElement('a');
-    a.href = 'http://domain.com/';
-    a.textContent = 'text';
-    var textNode = a.firstChild;
-
-    var aClone = a.cloneNode(true);
-    var textNodeClone = aClone.firstChild;
-
-    assert.equal(aClone.tagName, 'A');
-    assert.equal(aClone.href, 'http://domain.com/');
-    expectStructure(aClone, {
-      firstChild: textNodeClone,
-      lastChild: textNodeClone
-    });
-    expectStructure(textNodeClone, {
-      parentNode: aClone
-    });
-  });
-
-  test('parentElement', function() {
-    var a = document.createElement('a');
-    a.textContent = 'text';
-    var textNode = a.firstChild;
-    assert.equal(textNode.parentElement, a);
-    assert.isNull(a.parentElement);
-
-    var doc = wrap(document);
-    var body = doc.body;
-    var documentElement = doc.documentElement;
-    assert.equal(body.parentElement, documentElement);
-    assert.isNull(documentElement.parentElement);
-  });
-
-  test('contains', function() {
-    var div = document.createElement('div');
-    assert.isTrue(div.contains(div));
-
-    div.textContent = 'a';
-    var textNode = div.firstChild;
-    assert.isTrue(textNode.contains(textNode));
-    assert.isTrue(div.contains(textNode));
-    assert.isFalse(textNode.contains(div));
-
-    var doc = div.ownerDocument;
-    assert.isTrue(doc.contains(doc));
-    assert.isFalse(doc.contains(div));
-    assert.isFalse(doc.contains(textNode));
-
-    assert.isFalse(div.contains(null));
-    assert.isFalse(div.contains());
-  });
-
-  test('instanceof', function() {
-    var div = document.createElement('div');
-    assert.instanceOf(div, HTMLElement);
-    assert.instanceOf(div, Element);
-    assert.instanceOf(div, EventTarget);
   });
 
 });


### PR DESCRIPTION
The only way we could use the native cloneNode would be if we knew if there wasn't a shadow root in the current tree. We currently do not keep track of that state so always walk the tree when cloning.

Fixes #296 
