### PR TITLE
Disable the lineDashOffset test since it is not available in Firefox 25

### DIFF
--- a/test/js/HTMLCanvasElement.js
+++ b/test/js/HTMLCanvasElement.js
@@ -50,7 +50,10 @@ suite('HTMLCanvasElement', function() {
     assert.isString(context.textBaseline);
     assert.isString(context.textAlign);
     assert.isString(context.font);
-    assert.isNumber(context.lineDashOffset);
+
+    // lineDashOffset is not available in Firefox 25
+    // assert.isNumber(context.lineDashOffset);
+
     assert.isString(context.shadowColor);
     assert.isNumber(context.shadowBlur);
     assert.isNumber(context.shadowOffsetY);


### PR DESCRIPTION
Fixes #309
