### PR TITLE
Move Range.js in build.json to match what we do in shadowdom.js

### DIFF
--- a/build.json
+++ b/build.json
@@ -23,12 +23,12 @@
   "src/wrappers/HTMLUnknownElement.js",
   "src/wrappers/CanvasRenderingContext2D.js",
   "src/wrappers/WebGLRenderingContext.js",
+  "src/wrappers/Range.js",
   "src/wrappers/generic.js",
   "src/wrappers/ShadowRoot.js",
   "src/ShadowRenderer.js",
   "src/wrappers/elements-with-form-property.js",
   "src/wrappers/Document.js",
   "src/wrappers/Window.js",
-  "src/wrappers/Range.js",
   "src/wrappers/override-constructors.js"
 ]


### PR DESCRIPTION
This is basically to match the change here https://github.com/Polymer/ShadowDOM/commit/57cb3435c64b560f9db8af3396eaa929d55285b9#diff-7350cd3f3c3f571d71cc26670bcb779dR42 for the uglified code.
