### PR TITLE
Unwrap if needed for the reference node in insertBefore

### DIFF
--- a/src/wrappers.js
+++ b/src/wrappers.js
@@ -373,6 +373,7 @@ window.ShadowDOMPolyfill = {};
   scope.defineGetter = defineGetter;
   scope.defineWrapGetter = defineWrapGetter;
   scope.forwardMethodsToWrapper = forwardMethodsToWrapper;
+  scope.isWrapper = isWrapper;
   scope.isWrapperFor = isWrapperFor;
   scope.mixin = mixin;
   scope.nativePrototypeTable = nativePrototypeTable;

--- a/test/js/HTMLHtmlElement.js
+++ b/test/js/HTMLHtmlElement.js
@@ -27,6 +27,22 @@ suite('HTMLHtmlElement', function() {
     assert.equal(doc.documentElement.lastChild, b);
   });
 
+  test('insertBefore', function() {
+    var comment = document.createComment('comment');
+    var root = document.documentElement;
+    root.insertBefore(comment, root.firstChild);
+    assert.equal(wrap(root.firstChild), comment);
+  });
+
+  test('replaceChild', function() {
+    var comment = document.createComment('comment');
+    var comment2 = document.createComment('comment2');
+    var root = document.documentElement;
+    root.insertBefore(comment, root.firstChild);
+    assert.equal(wrap(root.firstChild), comment);
+    root.replaceChild(comment2, root.firstChild);
+  });
+
   test('matches', function() {
     // From jQuery.
     var html = document.documentElement;


### PR DESCRIPTION
Also, unwrap if needed for old child in replaceChild.

Fixes #319
