### PR TITLE
Use FocusEvent for testing for constructable events instead

### DIFF
--- a/src/wrappers/events.js
+++ b/src/wrappers/events.js
@@ -481,7 +481,7 @@
 
   var supportsEventConstructors = (function() {
     try {
-      new window.MouseEvent('click');
+      new window.FocusEvent('focus');
     } catch (ex) {
       return false;
     }


### PR DESCRIPTION
Constructable FocusEvent was implemented after constructable MouseEvent.
