### PR TITLE
Add work around for Firefox bug related to window methods

### DIFF
--- a/src/wrappers/Window.js
+++ b/src/wrappers/Window.js
@@ -27,12 +27,18 @@
                                          pseudo);
   };
 
+  // Work around for https://bugzilla.mozilla.org/show_bug.cgi?id=943065
+  delete window.getComputedStyle;
+
   ['addEventListener', 'removeEventListener', 'dispatchEvent'].forEach(
       function(name) {
         OriginalWindow.prototype[name] = function() {
           var w = wrap(this || window);
           return w[name].apply(w, arguments);
         };
+
+        // Work around for https://bugzilla.mozilla.org/show_bug.cgi?id=943065
+        delete window[name];
       });
 
   mixin(Window.prototype, {


### PR DESCRIPTION
https://bugzilla.mozilla.org/show_bug.cgi?id=943065

This is a regression in the nightly. Once fixed in Firefox the work around should be removed
