### PR TITLE
Use emulated dispatchEvent for EventTarget.prototype.dispatchEvent

### DIFF
--- a/test/js/events.js
+++ b/test/js/events.js
@@ -1333,4 +1333,32 @@ test('retarget order (multiple shadow roots)', function() {
     assert.isFalse('returnValue' in e);
   });
 
+  test('event propagation in shadow tree', function() {
+    var host = document.createElement('host');
+    host.innerHTML = ' <child></child> ';
+    var child = host.firstElementChild;
+
+    var root = host.createShadowRoot();
+    root.textContent = 'waiting...';
+
+    var data;
+    host.addEventListener('test', function(e) {
+      data = e.data;
+    });
+
+    function send(data) {
+      var e = new Event('test', {bubbles: true});
+      e.data = data;
+      child.dispatchEvent(e);
+    }
+
+    send('a');
+    assert.equal(data, 'a');
+
+    host.offsetWidth;
+
+    send('b');
+    assert.equal(data, 'b');
+  });
+
 });


### PR DESCRIPTION
If the code calls dispatchEvent then we go straight to the emulated path. This is important because the node might not be connected to the node where we have listeners on in the native tree.

Fixes #327
