### PR TITLE
Enhance compatibility with native custom elements

### DIFF
--- a/src/wrappers/Document.js
+++ b/src/wrappers/Document.js
@@ -162,7 +162,7 @@
         newPrototype[name] = function() {
           // if this element has been wrapped prior to registration,
           // the wrapper is stale; in this case rewrap
-          if (!(wrap(this) instanceof GeneratedWrapper)) {
+          if (!(wrap(this) instanceof CustomElementConstructor)) {
             rewrap(this);
           }
           f.apply(wrap(this), arguments);
@@ -173,7 +173,7 @@
       if (object.extends)
         p.extends = object.extends;
 
-      function GeneratedWrapper(node) {
+      function CustomElementConstructor(node) {
         if (!node) {
           if (object.extends) {
             return document.createElement(object.extends, tagName);
@@ -183,15 +183,15 @@
         }
         this.impl = node;
       }
-      GeneratedWrapper.prototype = prototype;
-      GeneratedWrapper.prototype.constructor = GeneratedWrapper;
+      CustomElementConstructor.prototype = prototype;
+      CustomElementConstructor.prototype.constructor = CustomElementConstructor;
 
-      scope.constructorTable.set(newPrototype, GeneratedWrapper);
+      scope.constructorTable.set(newPrototype, CustomElementConstructor);
       scope.nativePrototypeTable.set(prototype, newPrototype);
 
       // registration is synchronous so do it last
       var nativeConstructor = originalRegister.call(unwrap(this), tagName, p);
-      return GeneratedWrapper;
+      return CustomElementConstructor;
     };
 
     forwardMethodsToWrapper([

--- a/test/js/Document.js
+++ b/test/js/Document.js
@@ -430,7 +430,7 @@ htmlSuite('Document', function() {
         assert.instanceOf(this, A);
         self = this;
       }
-    }
+    };
 
     A = document.register('x-a2', A);
 
@@ -454,7 +454,7 @@ htmlSuite('Document', function() {
         assert.instanceOf(this, A);
       },
       isCustom: true
-    }
+    };
 
     A = document.register('x-a2-1', A);
   });
@@ -480,7 +480,7 @@ htmlSuite('Document', function() {
         assert.instanceOf(this, A);
         assert.equal(a, this);
       }
-    }
+    };
 
     A = document.register('x-a3', A);
 
@@ -519,7 +519,7 @@ htmlSuite('Document', function() {
         }
         console.log(arguments);
       }
-    }
+    };
 
     A = document.register('x-a4', A);
 
@@ -546,7 +546,7 @@ htmlSuite('Document', function() {
     A.prototype = {
       __proto__: HTMLElement.prototype,
       isCustom: true
-    }
+    };
 
     A = document.register('x-a6', A);
     // re-wrap after registration to update wrapper

--- a/test/js/Document.js
+++ b/test/js/Document.js
@@ -451,6 +451,7 @@ htmlSuite('Document', function() {
       __proto__: HTMLElement.prototype,
       createdCallback: function() {
         assert.isTrue(this.isCustom);
+        assert.instanceOf(this, A);
       },
       isCustom: true
     }

--- a/test/js/Document.js
+++ b/test/js/Document.js
@@ -439,6 +439,25 @@ htmlSuite('Document', function() {
     assert.equal(self, a);
   });
 
+  test('document.register createdCallback upgrade', function() {
+    if (!document.register)
+      return;
+
+    div = document.body.appendChild(document.createElement('div'));
+    div.innerHTML = '<x-a2-1></x-a2-1>';
+
+    function A() {}
+    A.prototype = {
+      __proto__: HTMLElement.prototype,
+      createdCallback: function() {
+        assert.isTrue(this.isCustom);
+      },
+      isCustom: true
+    }
+
+    A = document.register('x-a2-1', A);
+  });
+
   test('document.register enteredViewCallback, leftViewCallback',
       function() {
     if (!document.register)
@@ -511,6 +530,27 @@ htmlSuite('Document', function() {
     assert.equal(attributeChangedCalls, 2);
     a.removeAttribute('foo');
     assert.equal(attributeChangedCalls, 3);
+  });
+
+  test('document.register get reference, upgrade, rewrap', function() {
+    if (!document.register)
+      return;
+
+    div = document.body.appendChild(document.createElement('div'));
+    div.innerHTML = '<x-a6></x-a6>';
+    // get reference (creates wrapper)
+    div.firstChild;
+
+    function A() {}
+    A.prototype = {
+      __proto__: HTMLElement.prototype,
+      isCustom: true
+    }
+
+    A = document.register('x-a6', A);
+    // re-wrap after registration to update wrapper
+    ShadowDOMPolyfill.rewrap(ShadowDOMPolyfill.unwrap(div.firstChild));
+    assert.isTrue(div.firstChild.isCustom);
   });
 
   htmlTest('html/document-write.html');


### PR DESCRIPTION
This fixes issue #190.

Elements that are wrapped prior to custom element registration have stale wrappers. This is not addressed generically, but we do address it here in the custom element callbacks such that the element has the expected wrapper in these callbacks. If an element does not have one of these callbacks and is wrapped prior to registration, the user must 'rewrap' the element via:

```
ShadowDOMPolyfill.rewrap(ShadowDOMPolyfill.unwrap(element));
```

It's not possible to fix this generically since the invalid wrapper reference is held by the user.
