### PR TITLE
Avoid stack overflow when Element.matches is supported by the browser

### DIFF
--- a/src/wrappers/Element.js
+++ b/src/wrappers/Element.js
@@ -88,9 +88,11 @@
     }
   });
 
-  Element.prototype[matchesName] = function(selector) {
-    return this.matches(selector);
-  };
+  if (matchesName != "matches") {
+    Element.prototype[matchesName] = function(selector) {
+      return this.matches(selector);
+    };
+  }
 
   if (OriginalElement.prototype.webkitCreateShadowRoot) {
     Element.prototype.webkitCreateShadowRoot =


### PR DESCRIPTION
In http://crbug.com/326652 support for Element.matches(selectors) was
added to Blink, but it was reverted because it caused tests using
Polymer to start failing due to "Maximum call stack size
exceeded".

The problem is that the Element wrapper unconditionally implements
Element.prototype[matchesName] using this.matches(), which is the same
function if matchesName == "matches". Make the forwarding function
conditional to solve the problem.
