### PR TITLE
Do not create an applet element during startup

### DIFF
--- a/src/wrappers/override-constructors.js
+++ b/src/wrappers/override-constructors.js
@@ -11,7 +11,12 @@
   // for.
   var elements = {
     'a': 'HTMLAnchorElement',
-    'applet': 'HTMLAppletElement',
+
+    // Do not create an applet element by default since it shows a warning in
+    // IE.
+    // https://github.com/Polymer/polymer/issues/217
+    // 'applet': 'HTMLAppletElement',
+
     'area': 'HTMLAreaElement',
     'br': 'HTMLBRElement',
     'base': 'HTMLBaseElement',


### PR DESCRIPTION
By creating an applet element IE shows a user prompt.

Fixes https://github.com/Polymer/polymer/issues/217
