### PR TITLE
Fix issue with getElementById

### DIFF
--- a/src/wrappers/ShadowRoot.js
+++ b/src/wrappers/ShadowRoot.js
@@ -16,6 +16,8 @@
   var shadowHostTable = new WeakMap();
   var nextOlderShadowTreeTable = new WeakMap();
 
+  var spaceCharRe = /[ \t\n\r\f]/;
+
   function ShadowRoot(hostWrapper) {
     var node = unwrap(hostWrapper.impl.ownerDocument.createDocumentFragment());
     DocumentFragment.call(this, node);
@@ -56,7 +58,9 @@
     },
 
     getElementById: function(id) {
-      return this.querySelector('#' + id);
+      if (spaceCharRe.test(id))
+        return null;
+      return this.querySelector('[id="' + id + '"]');
     }
   });
 

--- a/test/js/ShadowRoot.js
+++ b/test/js/ShadowRoot.js
@@ -37,6 +37,26 @@ suite('ShadowRoot', function() {
     assert.equal(sr.getElementById('b'), b);
   });
 
+  test('getElementById with a non CSS ID', function() {
+    var div = document.createElement('div');
+    var sr = div.createShadowRoot();
+    sr.innerHTML = '<a id=1 name=2></a><b id=2></b>';
+    var a = sr.firstChild;
+    var b = sr.lastChild;
+
+    assert.equal(sr.getElementById(1), a);
+    assert.equal(sr.getElementById(2), b);
+  });
+
+  test('getElementById with a non ID', function() {
+    var div = document.createElement('div');
+    var sr = div.createShadowRoot();
+    sr.innerHTML = '<a id="a b"></a>';
+    var a = sr.firstChild;
+
+    assert.isNull(sr.getElementById('a b'));
+  });
+
   test('olderShadowRoot', function() {
     var host = document.createElement('div');
     host.innerHTML = '<a>a</a><b>b</b>';


### PR DESCRIPTION
`querySelector('#id')` only allows valid CSS IDs but `getElementById` should allow any character but "HTML space" characters.
