### PR TITLE
Blacklist keyLocation from all Events

### DIFF
--- a/src/wrappers/events.js
+++ b/src/wrappers/events.js
@@ -360,7 +360,12 @@
   };
 
   var OriginalEvent = window.Event;
-  OriginalEvent.prototype.polymerBlackList_ = {returnValue: true};
+  OriginalEvent.prototype.polymerBlackList_ = {
+    returnValue: true,
+    // TODO(arv): keyLocation is part of KeyboardEvent but Firefox does not
+    // support constructable KeyboardEvent so we keep it here for now.
+    keyLocation: true
+  };
 
   /**
    * Creates a new Event wrapper or wraps an existin native Event object.


### PR DESCRIPTION
Chrome warns about keyLocation.

KeyboardEvent is a bit buggy in Firefox so I decided to just put add the name to the Event blacklist.
