### PR TITLE
Make Node.textContent ignore comment nodes

### DIFF
--- a/src/wrappers/Node.js
+++ b/src/wrappers/Node.js
@@ -543,7 +543,9 @@
       // are no shadow trees below or above the context node.
       var s = '';
       for (var child = this.firstChild; child; child = child.nextSibling) {
-        s += child.textContent;
+        if (child.nodeType != Node.COMMENT_NODE) {
+          s += child.textContent;
+        }
       }
       return s;
     },

--- a/test/js/Node.js
+++ b/test/js/Node.js
@@ -298,10 +298,21 @@ suite('Node', function() {
     parent.insertBefore(c3);
     parent.insertBefore(c2, c3);
     parent.insertBefore(c1, c2);
-    
+
     assert.equal(parent.firstChild, c1);
     assert.equal(c1.nextElementSibling, c2);
     assert.equal(c2.nextElementSibling, c3);
+  });
+
+  test('textContent of comment', function() {
+    var comment = document.createComment('abc');
+    assert.equal(comment.textContent, 'abc');
+  });
+
+  test('textContent ignores comments', function() {
+    var div = document.createElement('div');
+    div.innerHTML = 'ab<!--cd-->ef';
+    assert.equal(div.textContent, 'abef');
   });
 
 });


### PR DESCRIPTION
Currently it is incorrectly including the text from comment nodes in generating textContent.
