### PR TITLE
Added a (failing) test for HTMLScriptElement.innerHTML

### DIFF
--- a/test/js/HTMLElement.js
+++ b/test/js/HTMLElement.js
@@ -80,4 +80,11 @@ suite('HTMLElement', function() {
     assert.equal(div.offsetWidth, 120);
   });
 
+  test('innerHTML', function() {
+    var script = document.createElement('script');
+    var html = '<x>{{y}}</x>';
+    script.innerHTML = html;
+    assert.equal(script.innerHTML, html);
+  });
+
 });


### PR DESCRIPTION
innerHTML handling for Script elements should use a different escape mechanism (or none?) from the rest of the elements.

This test currently fails because the innerHTML string for the script element is escaped to be `&lt;x>{{y}}&lt;/x>`. 

I encountered this issue when investigating why some Angular (Dart) tests were failing on ShadowDOM. Angular allows HTML templates from script elements.
