### PR TITLE
Fix element issue again

### DIFF
--- a/src/wrappers/Element.js
+++ b/src/wrappers/Element.js
@@ -126,7 +126,8 @@
   mixin(Element.prototype, ParentNodeInterface);
   mixin(Element.prototype, SelectorsInterface);
 
-  registerWrapper(OriginalElement, Element, document.createElement(null, 'x'));
+  registerWrapper(OriginalElement, Element,
+                  document.createElementNS(null, 'x'));
 
   // TODO(arv): Export setterDirtiesAttribute and apply it to more bindings
   // that reflect attributes.

--- a/test/js/SVGElement.js
+++ b/test/js/SVGElement.js
@@ -45,8 +45,8 @@ suite('SVGElement', function() {
 
     // IE does not create an SVGElement if the local name is not a known SVG
     // element.
-    if (!/Trident/.test(navigator.userAgent))
-      assert.instanceOf(el, SVGElement);
+    // Safari 7 has the same issue but nightly WebKit works as expected.
+    // assert.instanceOf(el, SVGElement);
 
     assert.instanceOf(el, Element);
     assert.instanceOf(el, Node);


### PR DESCRIPTION
The last one had a typo in it. It should have been using createElementNS in the first place.

Also, disable the `instanceof SVGElement` for svg/template since IE11 and Safari7 both break on it.
