### PR TITLE
Fix issue related to matches and jQuery

### DIFF
--- a/src/wrappers/Document.js
+++ b/src/wrappers/Document.js
@@ -13,7 +13,7 @@
   var defineWrapGetter = scope.defineWrapGetter;
   var elementFromPoint = scope.elementFromPoint;
   var forwardMethodsToWrapper = scope.forwardMethodsToWrapper;
-  var matchesName = scope.matchesName;
+  var matchesNames = scope.matchesNames;
   var mixin = scope.mixin;
   var registerWrapper = scope.registerWrapper;
   var unwrap = scope.unwrap;
@@ -221,8 +221,7 @@
     'querySelectorAll',
     'removeChild',
     'replaceChild',
-    matchesName,
-  ]);
+  ].concat(matchesNames));
 
   forwardMethodsToWrapper([
     window.HTMLDocument || window.Document,  // Gecko adds these to HTMLDocument

--- a/src/wrappers/Element.js
+++ b/src/wrappers/Element.js
@@ -19,12 +19,16 @@
 
   var OriginalElement = window.Element;
 
-  var matchesName = oneOf(OriginalElement.prototype, [
-    'matches',
+  var matchesNames = [
+    'matches',  // needs to come first.
     'mozMatchesSelector',
     'msMatchesSelector',
     'webkitMatchesSelector',
-  ]);
+  ].filter(function(name) {
+    return OriginalElement.prototype[name];
+  });
+
+  var matchesName = matchesNames[0];
 
   var originalMatches = OriginalElement.prototype[matchesName];
 
@@ -88,11 +92,13 @@
     }
   });
 
-  if (matchesName != "matches") {
-    Element.prototype[matchesName] = function(selector) {
-      return this.matches(selector);
-    };
-  }
+  matchesNames.forEach(function(name) {
+    if (name !== 'matches') {
+      Element.prototype[name] = function(selector) {
+        return this.matches(selector);
+      };
+    }
+  });
 
   if (OriginalElement.prototype.webkitCreateShadowRoot) {
     Element.prototype.webkitCreateShadowRoot =
@@ -131,6 +137,6 @@
 
   // TODO(arv): Export setterDirtiesAttribute and apply it to more bindings
   // that reflect attributes.
-  scope.matchesName = matchesName;
+  scope.matchesNames = matchesNames;
   scope.wrappers.Element = Element;
 })(window.ShadowDOMPolyfill);


### PR DESCRIPTION
Chrome Canary now ships with `Element.prototype.matches` so we ended up only forwarding `document.documentElement.matches` to the wrapper. With this patch we forward all of them (matches and webkitMatchesSelector/mozMatchesSelector/msMatchesSelector).
