### PR TITLE
Fix IE9 issue with shadow tree composition

### DIFF
--- a/src/ShadowRenderer.js
+++ b/src/ShadowRenderer.js
@@ -190,10 +190,18 @@
     if (!(node instanceof Element))
       return false;
 
+    // The native matches function in IE9 does not correctly work with elements
+    // that are not in the document.
+    // TODO(arv): Implement matching in JS.
+    // https://github.com/Polymer/ShadowDOM/issues/361
+    if (select === '*' || select === node.localName)
+      return true;
+
     // TODO(arv): This does not seem right. Need to check for a simple selector.
     if (!selectorMatchRegExp.test(select))
       return false;
 
+    // TODO(arv): This no longer matches the spec.
     if (select[0] === ':' && !allowedPseudoRegExp.test(select))
       return false;
 

--- a/src/wrappers/Node.js
+++ b/src/wrappers/Node.js
@@ -274,7 +274,7 @@
      * @private
      */
     this.previousSibling_ = undefined;
-  };
+  }
 
   var OriginalDocumentFragment = window.DocumentFragment;
   var originalAppendChild = OriginalNode.prototype.appendChild;


### PR DESCRIPTION
msMatchesSelector does not work on elements that are not in the document
