### PR TITLE
Fix IE9 issue with innerHTML on plaintext elements

### DIFF
--- a/src/wrappers/HTMLElement.js
+++ b/src/wrappers/HTMLElement.js
@@ -134,6 +134,9 @@
     }
   }
 
+  // IE11 does not have MSIE in the user agent string.
+  var oldIe = /MSIE/.test(navigator.userAgent);
+
   var OriginalHTMLElement = window.HTMLElement;
 
   function HTMLElement(node) {
@@ -147,6 +150,17 @@
       return getInnerHTML(this);
     },
     set innerHTML(value) {
+      // IE9 does not handle set innerHTML correctly on plaintextParents. It
+      // creates element children. For example
+      //
+      //   scriptElement.innerHTML = '<a>test</a>'
+      //
+      // Creates a single HTMLAnchorElement child.
+      if (oldIe && plaintextParents[this.localName]) {
+        this.textContent = value;
+        return;
+      }
+
       var removedNodes = snapshotNodeList(this.childNodes);
 
       if (this.invalidateShadowRenderer())


### PR DESCRIPTION
Setting innerHTML on plaintext elements creates non Text children.
Check if the element is a plaintext elemend and if so use textContent
instead.
