### PR TITLE
Workaround to don't crash when loading in Opera 12

### DIFF
--- a/src/wrappers/Document.js
+++ b/src/wrappers/Document.js
@@ -294,6 +294,15 @@
   wrapImplMethod(DOMImplementation, 'createHTMLDocument');
   forwardImplMethod(DOMImplementation, 'hasFeature');
 
+  // Opera don't support DOMImplementation, but it has document.implementation
+  // that can be used instead, but to be compatible with the registerWrapper
+  // it must be a prototype of constructor object (tested on Opera 12)
+  function operaDOMImplementation () {}
+  if (!window.DOMImplementation) {
+    operaDOMImplementation.prototype = document.implementation;
+    window.DOMImplementation = function operaDOMImplementation () {};
+  }
+
   registerWrapper(window.DOMImplementation, DOMImplementation);
 
   forwardMethodsToWrapper([

--- a/src/wrappers/Element.js
+++ b/src/wrappers/Element.js
@@ -24,6 +24,7 @@
     'mozMatchesSelector',
     'msMatchesSelector',
     'webkitMatchesSelector',
+    'oMatchesSelector',
   ].filter(function(name) {
     return OriginalElement.prototype[name];
   });


### PR DESCRIPTION
This lite fix make it load without errors in the Opera 12
