### PR TITLE
Always return an array for getDisributedNodes

### DIFF
--- a/src/ShadowRenderer.js
+++ b/src/ShadowRenderer.js
@@ -116,7 +116,10 @@
   }
 
   function getDistributedChildNodes(insertionPoint) {
-    return distributedChildNodesTable.get(insertionPoint);
+    var rv = distributedChildNodesTable.get(insertionPoint);
+    if (!rv)
+      distributedChildNodesTable.set(insertionPoint, rv = []);
+    return rv;
   }
 
   function getChildNodesSnapshot(node) {

--- a/test/js/HTMLContentElement.js
+++ b/test/js/HTMLContentElement.js
@@ -223,4 +223,9 @@ suite('HTMLContentElement', function() {
     host.offsetHeight;
     assert.equal(unwrap(host).innerHTML, '<b>fallback</b>');
   });
+
+  test('getDistributedNodes outside shadow dom', function() {
+    var content = document.createElement('content');
+    assert.deepEqual(content.getDistributedNodes(), []);
+  });
 });


### PR DESCRIPTION
Partial work around for https://github.com/Polymer/platform/issues/52
