### PR TITLE
Wrap setDragImage

### DIFF
--- a/build.json
+++ b/build.json
@@ -41,5 +41,6 @@
   "src/wrappers/Selection.js",
   "src/wrappers/Document.js",
   "src/wrappers/Window.js",
+  "src/wrappers/DataTransfer.js",
   "src/wrappers/override-constructors.js"
 ]

--- a/shadowdom.js
+++ b/shadowdom.js
@@ -57,6 +57,7 @@
     'src/wrappers/Selection.js',
     'src/wrappers/Document.js',
     'src/wrappers/Window.js',
+    'src/wrappers/DataTransfer.js',
     'src/wrappers/override-constructors.js'
   ].forEach(function(src) {
     document.write('<script src="' + base + src + '"></script>');

--- a/src/wrappers/DataTransfer.js
+++ b/src/wrappers/DataTransfer.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2014 The Polymer Authors. All rights reserved.
+ * Use of this source code is goverened by a BSD-style
+ * license that can be found in the LICENSE file.
+ */
+
+(function(scope) {
+  'use strict';
+
+  var unwrap = scope.unwrap;
+
+  // DataTransfer (Clipboard in old Blink/WebKit) has a single method that
+  // requires wrapping. Since it is only a method we do not need a real wrapper,
+  // we can just override the method.
+
+  var OriginalDataTransfer = window.DataTransfer || window.Clipboard;
+  var OriginalDataTransferSetDragImage =
+      OriginalDataTransfer.prototype.setDragImage;
+
+  OriginalDataTransfer.prototype.setDragImage = function(image, x, y) {
+    OriginalDataTransferSetDragImage.call(this, unwrap(image), x, y);
+  };
+
+})(window.ShadowDOMPolyfill);

--- a/test/manual/setDragImage.html
+++ b/test/manual/setDragImage.html
@@ -1,0 +1,19 @@
+<!doctype html>
+<script src="../../shadowdom.js"></script>
+
+<p>Drag the div below the image. When dragging the image should be used as the
+drag image.
+
+<p><img src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAIAAAACCAYAAABytg0kAAAAEklEQVQIW2NsYGj4zwAEjDAGACoaBAFwzZYuAAAAAElFTkSuQmCC" style="width: 100px; heigh: 100px">
+
+<p draggable=true>Drag me
+
+<script>
+
+var p = document.querySelector('[draggable]');
+var img = document.querySelector('img');
+p.ondragstart = function(e) {
+  e.dataTransfer.setDragImage(img, 50, 50);
+};
+
+</script>


### PR DESCRIPTION
Since DataTransfer only has one method that requires unwrapping of a param we just override that method instead of wrapping the whole interface.
