### PR TITLE
Events: Fix issue where we ignored null relatedTargets

### DIFF
--- a/src/wrappers/events.js
+++ b/src/wrappers/events.js
@@ -466,7 +466,11 @@
 
   var relatedTargetProto = {
     get relatedTarget() {
-      return relatedTargetTable.get(this) || wrap(unwrap(this).relatedTarget);
+      var relatedTarget = relatedTargetTable.get(this);
+      // relatedTarget can be null.
+      if (relatedTarget !== undefined)
+        return relatedTarget;
+      return wrap(unwrap(this).relatedTarget);
     }
   };
 


### PR DESCRIPTION
We set the relatedTarget to null in a few cases to work around bugs
in IE, but we ignored null due to the falsey check in the getter.
