### PR TITLE
Minor tweaks to reuse objects and skip forEach during boot

### DIFF
--- a/src/wrappers/NodeList.js
+++ b/src/wrappers/NodeList.js
@@ -7,8 +7,10 @@
 
   var wrap = scope.wrap;
 
+  var nonEnumDescriptor = {enumerable: false};
+
   function nonEnum(obj, prop) {
-    Object.defineProperty(obj, prop, {enumerable: false});
+    Object.defineProperty(obj, prop, nonEnumDescriptor);
   }
 
   function NodeList() {


### PR DESCRIPTION
Reuse the descriptor objects where possible. For non generational
GC this reduces the GC churn.

Use c-style for loops instead of forEach since forEach is slow
