### PR TITLE
appendChild from a tree with a rendered causes failures

### DIFF
--- a/src/wrappers/Node.js
+++ b/src/wrappers/Node.js
@@ -401,8 +401,11 @@
       } else {
         if (!previousNode)
           this.firstChild_ = nodes[0];
-        if (!refWrapper)
+        if (!refWrapper) {
           this.lastChild_ = nodes[nodes.length - 1];
+          if (this.firstChild_ === undefined)
+            this.firstChild_ = this.firstChild;
+        }
 
         var parentNode = refNode ? refNode.parentNode : this.impl;
 

--- a/test/js/Node.js
+++ b/test/js/Node.js
@@ -392,4 +392,25 @@ suite('Node', function() {
     assert.equal(sr.firstChild.nextSibling.textContent, 'quux');
   });
 
+  test('appendChild last and first', function() {
+    var a = document.createElement('a');
+    a.innerHTML = '<b></b>';
+    var b = a.firstChild;
+    var sr = a.createShadowRoot();
+
+    var c = document.createElement('c');
+    c.innerHTML = '<d></d>';
+    var d = c.firstChild;
+    c.appendChild(b);
+
+    var cs = c.childNodes;
+    assert.equal(cs.length, 2);
+    assert.equal(cs[0], d);
+    assert.equal(cs[1], b);
+
+    c.removeChild(b);
+    cs = c.childNodes;
+    assert.equal(cs.length, 1);
+    assert.equal(cs[0], d);
+  });
 });


### PR DESCRIPTION
The following fails to correctly update the internal pointers.

treeWithoutRenderer.appendChild(childFromParentWithRenderer)

Fixes #438
