### PR TITLE
Fix issue with DOMTokenList

### DIFF
--- a/build.json
+++ b/build.json
@@ -14,6 +14,7 @@
   "src/wrappers/node-interfaces.js",
   "src/wrappers/CharacterData.js",
   "src/wrappers/Text.js",
+  "src/wrappers/DOMTokenList.js",
   "src/wrappers/Element.js",
   "src/wrappers/HTMLElement.js",
   "src/wrappers/HTMLCanvasElement.js",

--- a/test/js/build-json.js
+++ b/test/js/build-json.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2014 The Polymer Authors. All rights reserved.
+ * Use of this source code is goverened by a BSD-style
+ * license that can be found in the LICENSE file.
+ */
+
+suite('build.json', function() {
+
+  teardown(function() {
+    delete document.write;
+  });
+
+  test('Ensure lists match', function(done) {
+    var xhrJson = new XMLHttpRequest;
+    xhrJson.open('GET', '../build.json');
+    xhrJson.onload = function() {
+      var buildJson = JSON.parse(xhrJson.responseText);
+
+      var xhrJs = new XMLHttpRequest;
+      xhrJs.open('GET', '../shadowdom.js');
+      xhrJs.onload = function() {
+        var sources = [];
+
+        document.write = function(s) {
+          var path =
+              s.slice('<script src="../'.length, - '"><\/script>'.length);
+          sources.push(path);
+        };
+
+        ('global', eval)(xhrJs.responseText);
+
+        assert.deepEqual(buildJson, sources);
+
+        done();
+      };
+      xhrJs.send(null);
+    };
+    xhrJson.send();
+  });
+
+});

--- a/test/test.main.js
+++ b/test/test.main.js
@@ -75,8 +75,8 @@ mocha.setup({
 var modules = [
   'ChildNodeInterface.js',
   'Comment.js',
-  'Document.js',
   'DOMTokenList.js',
+  'Document.js',
   'Element.js',
   'HTMLAudioElement.js',
   'HTMLBodyElement.js',
@@ -122,6 +122,7 @@ var modules = [
   'TouchEvent.js',
   'TreeScope.js',
   'Window.js',
+  'build-json.js',
   'createTable.js',
   'custom-element.js',
   'events.js',


### PR DESCRIPTION
The build.json file did not include DOMTokenList leading to
classList being brokon in 0.3.0

This adds a test that ensures that the list of files is in sync so
that these kind of errors do not happen again.

Fixes #445
