### PR TITLE
SVGElement does not have classList in IE

### DIFF
--- a/src/wrappers/SVGElement.js
+++ b/src/wrappers/SVGElement.js
@@ -5,12 +5,24 @@
 (function(scope) {
   'use strict';
 
+  var Element = scope.wrappers.Element;
+  var HTMLElement = scope.wrappers.HTMLElement;
   var registerObject = scope.registerObject;
 
   var SVG_NS = 'http://www.w3.org/2000/svg';
   var svgTitleElement = document.createElementNS(SVG_NS, 'title');
   var SVGTitleElement = registerObject(svgTitleElement);
   var SVGElement = Object.getPrototypeOf(SVGTitleElement.prototype).constructor;
+
+  // IE11 does not have classList for SVG elements. The spec says that classList
+  // is an accessor on Element, but IE11 puts classList on HTMLElement, leaving
+  // SVGElement without a classList property. We therefore move the accessor for
+  // IE11.
+  if (!('classList' in window.SVGElement)) {
+    var descr = Object.getOwnPropertyDescriptor(Element.prototype, 'classList');
+    Object.defineProperty(HTMLElement.prototype, 'classList', descr);
+    delete Element.prototype.classList;
+  }
 
   scope.wrappers.SVGElement = SVGElement;
 })(window.ShadowDOMPolyfill);

--- a/test/js/SVGElement.js
+++ b/test/js/SVGElement.js
@@ -54,4 +54,18 @@ suite('SVGElement', function() {
     assert.notInstanceOf(el, HTMLElement);
   });
 
+  test('classList', function() {
+    var el = document.createElementNS(SVG_NS, 'svg');
+    el.setAttribute('class', 'a b');
+
+    assert.isTrue(el.classList === undefined ||
+                  (el.classList instanceof DOMTokenList));
+
+    if (el.classList !== undefined) {
+      assert.equal(el.classList.length, 2);
+      assert.isTrue(el.classList.contains('a'));
+      assert.isTrue(el.classList.contains('b'));
+    }
+  });
+
 });


### PR DESCRIPTION
We therefore move it to HTMLElement so that code that does feature
detection of classList will work correctly in IE.

Fixes #454
