### PR TITLE
fix form.elements -- this is used by NodeBind getAssociatedRadioButtons

### DIFF
--- a/build.json
+++ b/build.json
@@ -19,6 +19,7 @@
   "src/wrappers/HTMLElement.js",
   "src/wrappers/HTMLCanvasElement.js",
   "src/wrappers/HTMLContentElement.js",
+  "src/wrappers/HTMLFormElement.js",
   "src/wrappers/HTMLImageElement.js",
   "src/wrappers/HTMLShadowElement.js",
   "src/wrappers/HTMLTemplateElement.js",

--- a/shadowdom.js
+++ b/shadowdom.js
@@ -35,6 +35,7 @@
     'src/wrappers/HTMLElement.js',
     'src/wrappers/HTMLCanvasElement.js',
     'src/wrappers/HTMLContentElement.js',
+    'src/wrappers/HTMLFormElement.js',
     'src/wrappers/HTMLImageElement.js',
     'src/wrappers/HTMLShadowElement.js',
     'src/wrappers/HTMLTemplateElement.js',

--- a/src/wrappers/HTMLFormElement.js
+++ b/src/wrappers/HTMLFormElement.js
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2014 The Polymer Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ */
+
+(function(scope) {
+  'use strict';
+
+  var HTMLElement = scope.wrappers.HTMLElement;
+  var mixin = scope.mixin;
+  var registerWrapper = scope.registerWrapper;
+  var wrapHTMLCollection = scope.wrapHTMLCollection;
+  var unwrap = scope.unwrap;
+
+  var OriginalHTMLFormElement = window.HTMLFormElement;
+
+  function HTMLFormElement(node) {
+    HTMLElement.call(this, node);
+  }
+  HTMLFormElement.prototype = Object.create(HTMLElement.prototype);
+  mixin(HTMLFormElement.prototype, {
+    get elements() {
+      // Note: technically this should be an HTMLFormControlsCollection, but
+      // that inherits from HTMLCollection, so should be good enough. Spec:
+      // http://www.whatwg.org/specs/web-apps/current-work/multipage/common-dom-interfaces.html#htmlformcontrolscollection
+      return wrapHTMLCollection(unwrap(this).elements);
+    }
+  });
+
+  registerWrapper(OriginalHTMLFormElement, HTMLFormElement,
+                  document.createElement('form'));
+
+  scope.wrappers.HTMLFormElement = HTMLFormElement;
+})(window.ShadowDOMPolyfill);

--- a/test/js/HTMLFormElement.js
+++ b/test/js/HTMLFormElement.js
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2014 The Polymer Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style
+ * license that can be found in the LICENSE file.
+ */
+
+suite('HTMLFormElement', function() {
+
+  test('elements', function() {
+    var form = document.createElement('form');
+    var input = document.createElement('input');
+    form.appendChild(input);
+    assert.instanceOf(form.elements, HTMLCollection);
+    assert.equal(form.elements.length, 1);
+  });
+
+});

--- a/test/test.main.js
+++ b/test/test.main.js
@@ -85,6 +85,7 @@ var modules = [
   'HTMLContentElement.js',
   'HTMLElement.js',
   'HTMLFieldSetElement.js',
+  'HTMLFormElement.js',
   'HTMLHeadElement.js',
   'HTMLHtmlElement.js',
   'HTMLImageElement.js',


### PR DESCRIPTION
form.elements should return an HTMLCollection.

this code in [NodeBind.js](https://github.com/Polymer/NodeBind/blob/master/src/NodeBind.js#L208)

``` js
     return filter(element.form.elements, function(el) {
        return el != element &&
            el.tagName == 'INPUT' &&
            el.type == 'radio' &&
            el.name == element.name;
      });
```

...uses form.elements, which was returning unwrapped nodes under SD polyfill.  This later causes an error because Node.bind stores bindings_ on the wrapper, and when it doesn't find the data it stored, blows up with a TypeError.

Caught this by running NodeBind tests with platform.js (normally they don't run with SD polyfill -- maybe they should?)
