### PR TITLE
unwrap(FormData) fails on Firefox

### DIFF
--- a/src/wrappers.js
+++ b/src/wrappers.js
@@ -301,6 +301,7 @@ window.ShadowDOMPolyfill = {};
            object instanceof OriginalRange ||
            object instanceof OriginalDOMImplementation ||
            object instanceof OriginalCanvasRenderingContext2D ||
+           object instanceof OriginalFormData ||
            OriginalWebGLRenderingContext &&
                object instanceof OriginalWebGLRenderingContext ||
            OriginalSVGElementInstance &&

--- a/src/wrappers.js
+++ b/src/wrappers.js
@@ -289,6 +289,7 @@ window.ShadowDOMPolyfill = {};
            object instanceof wrappers.Range ||
            object instanceof wrappers.DOMImplementation ||
            object instanceof wrappers.CanvasRenderingContext2D ||
+           object instanceof wrappers.FormData ||
            wrappers.WebGLRenderingContext &&
                object instanceof wrappers.WebGLRenderingContext;
   }

--- a/src/wrappers.js
+++ b/src/wrappers.js
@@ -282,7 +282,8 @@ window.ShadowDOMPolyfill = {};
   var OriginalCanvasRenderingContext2D = window.CanvasRenderingContext2D;
   var OriginalWebGLRenderingContext = window.WebGLRenderingContext;
   var OriginalSVGElementInstance = window.SVGElementInstance;
-
+  var OriginalFormData = window.FormData;
+  
   function isWrapper(object) {
     return object instanceof wrappers.EventTarget ||
            object instanceof wrappers.Event ||

--- a/src/wrappers/FormData.js
+++ b/src/wrappers/FormData.js
@@ -13,7 +13,10 @@
   var OriginalFormData = window.FormData;
 
   function FormData(formElement) {
-    this.impl = new OriginalFormData(formElement && unwrap(formElement));
+  	if (formElement instanceof OriginalFormData)
+  		this.impl = formElement;
+  	else
+	    this.impl = new OriginalFormData(formElement && unwrap(formElement));
   }
 
   registerWrapper(OriginalFormData, FormData, new OriginalFormData());

--- a/src/wrappers/FormData.js
+++ b/src/wrappers/FormData.js
@@ -13,10 +13,10 @@
   var OriginalFormData = window.FormData;
 
   function FormData(formElement) {
-  	if (formElement instanceof OriginalFormData)
-  		this.impl = formElement;
-  	else
-	    this.impl = new OriginalFormData(formElement && unwrap(formElement));
+    if (formElement instanceof OriginalFormData)
+      this.impl = formElement;
+    else
+      this.impl = new OriginalFormData(formElement && unwrap(formElement));
   }
 
   registerWrapper(OriginalFormData, FormData, new OriginalFormData());

--- a/test/js/FormData.js
+++ b/test/js/FormData.js
@@ -6,8 +6,8 @@
 
 suite('FormData', function() {
 
-	var wrap = ShadowDOMPolyfill.wrap;
-	var unwrap = ShadowDOMPolyfill.unwrap;
+  var wrap = ShadowDOMPolyfill.wrap;
+  var unwrap = ShadowDOMPolyfill.unwrap;
 
   test('instanceof', function() {
     var fd = new FormData();
@@ -20,11 +20,11 @@ suite('FormData', function() {
     assert.instanceOf(fd, FormData);
   });
 
-	test('wrap/unwrap', function() {
-	  var fd = new FormData();
-	  var unwrapped = unwrap(fd);
-	  var wrapped = wrap(unwrapped);
-	  assert.equal(fd.impl, wrapped.impl);
-	});
+  test('wrap/unwrap', function() {
+    var fd = new FormData();
+    var unwrapped = unwrap(fd);
+    var wrapped = wrap(unwrapped);
+    assert.equal(fd.impl, wrapped.impl);
+  });
 
 });

--- a/test/js/FormData.js
+++ b/test/js/FormData.js
@@ -6,6 +6,9 @@
 
 suite('FormData', function() {
 
+	var wrap = ShadowDOMPolyfill.wrap;
+	var unwrap = ShadowDOMPolyfill.unwrap;
+
   test('instanceof', function() {
     var fd = new FormData();
     assert.instanceOf(fd, FormData);
@@ -16,5 +19,12 @@ suite('FormData', function() {
     var fd = new FormData(formElement)
     assert.instanceOf(fd, FormData);
   });
+
+	test('wrap/unwrap', function() {
+	  var fd = new FormData();
+	  var unwrapped = unwrap(fd);
+	  var wrapped = wrap(unwrapped);
+	  assert.equal(fd.impl, wrapped.impl);
+	});
 
 });


### PR DESCRIPTION
unwrap(FormData) did not unwrap on Firefox. Traced it down to failure of isWrapper function. One line fix above.
I needed to unwrap FormData to pass it to xhr.send()

This fixes one case only. Looking at wrappers, looks like all of these are wrapped on FF, and only a small subset is valid in 'isWrapper'. This might be a bigger fix. I am not familiar with your internals, but it looks like isWrapper could be implemented as:
        if ('impl' in object)
testing instanceof walks prototype chain, and doing instanceof for all the wrappers below would be very slow.

wrappers in Firefox:

Audio
BeforeUnloadEvent
CanvasRenderingContext2D
CharacterData
Comment
CustomEvent
DOMImplementation
DOMTokenList
Document
DocumentFragment
Element
Event
EventTarget
FocusEvent
FormData
HTMLAudioElement
HTMLButtonElement
HTMLCanvasElement
HTMLCollection
HTMLContentElement
HTMLElement
HTMLFieldSetElement
HTMLFormElement
HTMLImageElement
HTMLInputElement
HTMLLabelElement
HTMLLegendElement
HTMLMediaElement
HTMLObjectElement
HTMLOptionElement
HTMLOutputElement
HTMLSelectElement
HTMLShadowElement
HTMLTableElement
HTMLTableRowElement
HTMLTableSectionElement
HTMLTemplateElement
HTMLTextAreaElement
HTMLUnknownElement
Image
MouseEvent
MutationObserver
Node
NodeList
Option
Range
SVGElement
SVGUseElement
Selection
ShadowRoot
Text
UIEvent
WebGLRenderingContext
Window
