### PR TITLE
Added IE 10 support

### DIFF
--- a/src/querySelector.js
+++ b/src/querySelector.js
@@ -23,7 +23,7 @@
   var originalElementGetElementsByTagNameNS = document.documentElement.getElementsByTagNameNS;
 
   var OriginalElement = window.Element;
-  var OriginalDocument = window.HTMLDocument;
+  var OriginalDocument = window.HTMLDocument || window.Document;
 
   function filterNodeList(list, index, result) {
     var wrappedItem = null;


### PR DESCRIPTION
I use Polymer in my project, but there was a problem, that it was not working on IE 10. I figured out that window.HTMLDocument is not available in IE 10, there is window.Document object instead. 

After this change everything is working. 
