### PR TITLE
Bypassing element wrapping for elements that do not exist

### DIFF
--- a/src/wrappers/HTMLAudioElement.js
+++ b/src/wrappers/HTMLAudioElement.js
@@ -12,6 +12,8 @@
 
   var OriginalHTMLAudioElement = window.HTMLAudioElement;
 
+  if (!OriginalHTMLAudioElement) return;
+
   function HTMLAudioElement(node) {
     HTMLMediaElement.call(this, node);
   }

--- a/src/wrappers/HTMLMediaElement.js
+++ b/src/wrappers/HTMLMediaElement.js
@@ -10,6 +10,8 @@
 
   var OriginalHTMLMediaElement = window.HTMLMediaElement;
 
+  if (!OriginalHTMLMediaElement) return;
+
   function HTMLMediaElement(node) {
     HTMLElement.call(this, node);
   }


### PR DESCRIPTION
This simply shorts out of the wrapping process if the native element doesn't exist, which can be the case for media related elements (HTMLAudioElement, HTMLVideoElement, etc) in headless browsers or browsers explicitly compiled without libraries that enable support for such elements (not uncommon for custom CEF builds).

This is the most obvious remaining issue before phantomjs v2 has basic testable support for platform.js and polymer.

I submitted the CLA and no tests seem to be affected (in Chrome, Chrome Canary, Firefox, Safari). If anything's not in order, feel free to close the PR and apply the change yourself, it's a trivial one.
