### PR TITLE
restore isLoadLikeEvent

### DIFF
--- a/src/wrappers/events.js
+++ b/src/wrappers/events.js
@@ -237,6 +237,19 @@
     }
   }
 
+
+  function isLoadLikeEvent(event) {
+    switch (event.type) {
+      // http://www.whatwg.org/specs/web-apps/current-work/multipage/webappapis.html#events-and-the-window-object
+      case 'load':
+      // http://www.whatwg.org/specs/web-apps/current-work/multipage/browsers.html#unloading-documents
+      case 'beforeunload':
+      case 'unload':
+        return true;
+    }
+    return false;
+  }
+
   function dispatchEvent(event, originalWrapperTarget) {
     if (currentlyDispatchingEvents.get(event))
       throw new Error('InvalidStateError');
@@ -254,12 +267,11 @@
     // http://www.whatwg.org/specs/web-apps/current-work/multipage/the-end.html#the-end
     var overrideTarget;
     var win;
-    var type = event.type;
 
     // Should really be not cancelable too but since Firefox has a bug there
     // we skip that check.
     // https://bugzilla.mozilla.org/show_bug.cgi?id=999456
-    if (type === 'load' && !event.bubbles) {
+    if (isLoadLikeEvent(event) && !event.bubbles) {
       var doc = originalWrapperTarget;
       if (doc instanceof wrappers.Document && (win = doc.defaultView)) {
         overrideTarget = doc;
@@ -274,7 +286,7 @@
       } else {
         eventPath = getEventPath(originalWrapperTarget, event);
 
-        if (event.type !== 'load') {
+        if (!isLoadLikeEvent(event)) {
           var doc = eventPath[eventPath.length - 1];
           if (doc instanceof wrappers.Document)
             win = doc.defaultView;

--- a/test/html/on-unload-test.html
+++ b/test/html/on-unload-test.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<script src="../../../tools/test/chai/chai.js"></script>
+<script src="../../../tools/test/htmltest.js"></script>
+<script src="../../shadowdom.js"></script>
+<script>
+
+var assert = chai.assert;
+var doc = ShadowDOMPolyfill.wrap(document);
+
+var beforeunloadCalled = 0;
+window.addEventListener('beforeunload', function(e) {
+  assert.equal(e.target, doc);
+  beforeunloadCalled++;
+});
+
+window.addEventListener('unload', function(e) {
+  assert.equal(beforeunloadCalled, 1);
+  assert.equal(e.target, doc);
+  done();
+});
+
+window.addEventListener('load', function(e) {
+  window.location.href = 'about:blank';
+});
+
+</script>

--- a/test/js/events.js
+++ b/test/js/events.js
@@ -928,6 +928,7 @@ test('retarget order (multiple shadow roots)', function() {
   });
 
   htmlTest('html/on-load-test.html');
+  htmlTest('html/on-unload-test.html');
 
   test('event wrap round trip', function() {
     var e = new Event('x');


### PR DESCRIPTION
fixes https://github.com/Polymer/platform/issues/83

isLoadLikeEvent is from: https://github.com/Polymer/ShadowDOM/commit/b04881f3b00925daa96b6c7256fb046d9706d499#diff-960ceb36e2dc9470f018834bd9019745L190

I wrote the test first to verify it reproduces the issue (it passes if shadowdom.js+wrap call is not there, before the fix and with shadowdom.js, it fails at the 2000ms timeout)
