### PR TITLE
Re-land fix for unload/beforeunload events

### DIFF
--- a/test/html/on-unload-test.html
+++ b/test/html/on-unload-test.html
@@ -1,0 +1,43 @@
+<!DOCTYPE html>
+<script src="../../../tools/test/chai/chai.js"></script>
+<script src="../../../tools/test/htmltest.js"></script>
+<script src="../../shadowdom.js"></script>
+<script>
+// Note: this test will navigate away from the page. It is designed to be run
+// in an iframe. Use ShadowDOM/test/runner.html?grep=unload for running it by
+// itself.
+
+function runTest() {
+  var assert = chai.assert;
+  var doc = ShadowDOMPolyfill.wrap(document);
+  var win = ShadowDOMPolyfill.wrap(window);
+
+  // Note: IE gives `window` as the target for beforeunload/unload. Others give
+  // document. It's not clear than anyone gets it right, my reading of the
+  // current spec is target should be window for beforeunload, but is overridden
+  // to be document for unload. Both events are dispatched on window:
+  // http://www.whatwg.org/specs/web-apps/current-work/multipage/browsers.html#unloading-documents
+  var expectedTarget = /Trident/.test(navigator.userAgent) ? win : doc;
+
+  var beforeunloadCalled = 0;
+  window.addEventListener('beforeunload', function(e) {
+    beforeunloadCalled++;
+    assert.equal(e.target, expectedTarget);
+  });
+
+  window.addEventListener('unload', function(e) {
+    assert.equal(beforeunloadCalled, 1);
+    assert.equal(e.target, expectedTarget);
+    done();
+  });
+
+  location.href = 'about:blank';
+}
+
+document.addEventListener('DOMContentLoaded', function(e) {
+  // Note: setTimeout makes IE happy. If document.readyState == 'interactive'
+  // at the time we run the tests, IE won't fire an unload in the iframe.
+  setTimeout(runTest, 0);
+});
+
+</script>

--- a/test/js/events.js
+++ b/test/js/events.js
@@ -928,6 +928,7 @@ test('retarget order (multiple shadow roots)', function() {
   });
 
   htmlTest('html/on-load-test.html');
+  htmlTest('html/on-unload-test.html');
 
   test('event wrap round trip', function() {
     var e = new Event('x');


### PR DESCRIPTION
The implementation code change compared to last time is fixes a stack overflow in the BeforeUnloadEvent polyfill, which the new test is hitting. This affected Safari which doesn't have a native BeforeUnloadEvent yet.

The test has several fixes for IE 10/11. IE had two different problems: e.target is window vs document in others, and the unload event won't fire in an iframe unless we setTimeout(0) before adding the handler.

This fixes https://github.com/Polymer/platform/issues/83

@kegluneq @arv mind taking another look?
