### PR TITLE
delete getDefaultComputedStyle from window

### DIFF
--- a/src/wrappers/Window.js
+++ b/src/wrappers/Window.js
@@ -42,6 +42,7 @@
 
   // Work around for https://bugzilla.mozilla.org/show_bug.cgi?id=943065
   delete window.getComputedStyle;
+  delete window.getDefaultComputedStyle;
   delete window.getSelection;
 
   ['addEventListener', 'removeEventListener', 'dispatchEvent'].forEach(


### PR DESCRIPTION
Looks like this was overlooked in https://github.com/Polymer/ShadowDOM/commit/864ca98, polyfill does not take affect in firefox without it.
