### PR TITLE
Fix for "TypeError: Argument 1 of Window.getComputedStyle does not implement interface Element."

### DIFF
--- a/src/wrappers/Window.js
+++ b/src/wrappers/Window.js
@@ -59,7 +59,7 @@
   mixin(Window.prototype, {
     getComputedStyle: function(el, pseudo) {
       renderAllPending();
-      if (el instanceof HTMLDocument) {
+      if (!(el instanceof HTMLElement)) {
         return true;
       }
       return originalGetComputedStyle.call(unwrap(this), unwrapIfNeeded(el),

--- a/src/wrappers/Window.js
+++ b/src/wrappers/Window.js
@@ -59,6 +59,9 @@
   mixin(Window.prototype, {
     getComputedStyle: function(el, pseudo) {
       renderAllPending();
+      if (el instanceof HTMLDocument) {
+        return true;
+      }
       return originalGetComputedStyle.call(unwrap(this), unwrapIfNeeded(el),
                                            pseudo);
     },


### PR DESCRIPTION
I got that error on canvas element, and the reason was that because of event bubbling event comes to `document` where this method fails.
Did not tested for error `TypeError: Argument 1 of Window.getDefaultComputedStyle does not implement interface Element.` but it may fix it in some cases as well.
