### PR TITLE
fixes #504, avoids global list of all MutationObservers

### DIFF
--- a/src/MutationObserver.js
+++ b/src/MutationObserver.js
@@ -15,7 +15,7 @@
   var globalMutationObservers = [];
   var isScheduled = false;
 
-  function scheduleCallback(observer) {
+  function scheduleCallback() {
     if (isScheduled)
       return;
     setEndOfMicrotask(notifyObservers);
@@ -26,20 +26,24 @@
   function notifyObservers() {
     isScheduled = false;
 
-    do {
-      var notifyList = globalMutationObservers.slice();
-      var anyNonEmpty = false;
+    while (globalMutationObservers.length) {
+      var notifyList = globalMutationObservers;
+      globalMutationObservers = [];
+
+      // Deliver changes in birth order of the MutationObservers.
+      notifyList.sort(function(x, y) { return x.uid_ - y.uid_; });
+
       for (var i = 0; i < notifyList.length; i++) {
         var mo = notifyList[i];
         var queue = mo.takeRecords();
         removeTransientObserversFor(mo);
         if (queue.length) {
           mo.callback_(queue, mo);
-          anyNonEmpty = true;
         }
       }
-    } while (anyNonEmpty);
+    }
   }
+
 
   /**
    * @param {string} type
@@ -146,7 +150,7 @@
       }
     }
 
-    var anyRecordsEnqueued = false;
+    var anyObserversEnqueued = false;
 
     // 4.
     for (var uid in interestedObservers) {
@@ -180,12 +184,14 @@
         record.oldValue = associatedStrings[uid];
 
       // 8.
+      if (!observer.records_.length) {
+        globalMutationObservers.push(observer);
+        anyObserversEnqueued = true;
+      }
       observer.records_.push(record);
-
-      anyRecordsEnqueued = true;
     }
 
-    if (anyRecordsEnqueued)
+    if (anyObserversEnqueued)
       scheduleCallback();
   }
 
@@ -249,9 +255,6 @@
     this.nodes_ = [];
     this.records_ = [];
     this.uid_ = ++uidCounter;
-
-    // This will leak. There is no way to implement this without WeakRefs :'(
-    globalMutationObservers.push(this);
   }
 
   MutationObserver.prototype = {


### PR DESCRIPTION
They're now added to the global list on-demand, and it is sorted by ID before delivering. Sounds like this is similar to the Blink implementation (https://github.com/Polymer/ShadowDOM/issues/504#issuecomment-55013158)
