### PR TITLE
Add workaround for broken Safari 8 DOM

### DIFF
--- a/src/wrappers.js
+++ b/src/wrappers.js
@@ -174,6 +174,15 @@ window.ShadowDOMPolyfill = {};
     }
   }
 
+  // Safari 8 exposes WebIDL attributes as an invalid accessor property. Its
+  // descriptor has {get: undefined, set: undefined}. We therefore ignore the
+  // shape of the descriptor and make all properties read-write.
+  // https://bugs.webkit.org/show_bug.cgi?id=49739
+  var isBrokenSafari = function() {
+    var descr = Object.getOwnPropertyDescriptor(Node.prototype, 'nodeType');
+    return !!descr && 'set' in descr;
+  }();
+
   function installProperty(source, target, allowMethod, opt_blacklist) {
     var names = getOwnPropertyNames(source);
     for (var i = 0; i < names.length; i++) {
@@ -204,7 +213,7 @@ window.ShadowDOMPolyfill = {};
       else
         getter = getGetter(name);
 
-      if (descriptor.writable || descriptor.set) {
+      if (descriptor.writable || descriptor.set || isBrokenSafari) {
         if (isEvent)
           setter = scope.getEventHandlerSetter(name);
         else


### PR DESCRIPTION
Safari's DOM is broken. It is returns invalid descriptors. We therefore
treat all properties as read-write even if they are really read only.

Fixes https://github.com/Polymer/platform/issues/66
