### PR TITLE
Throw an Error if window.FormData is undefined.

### DIFF
--- a/src/wrappers/FormData.js
+++ b/src/wrappers/FormData.js
@@ -13,6 +13,10 @@
 
   var OriginalFormData = window.FormData;
 
+  if(!OriginalFormData) {
+    throw new Error("window.FormData is undefined.");
+  }
+
   function FormData(formElement) {
     var impl;
     if (formElement instanceof OriginalFormData) {


### PR DESCRIPTION
This would address #508 by throwing an error if FormData is undefined.

I'd be happy to write find/write a polyfill if it's preferred to address the issue that way.
