### PR TITLE
Guard FormData for IE9

### DIFF
--- a/src/wrappers/FormData.js
+++ b/src/wrappers/FormData.js
@@ -12,6 +12,7 @@
   var unwrap = scope.unwrap;
 
   var OriginalFormData = window.FormData;
+  if (!OriginalFormData) return;
 
   function FormData(formElement) {
     var impl;


### PR DESCRIPTION
Since old IE does not have FormData we need to not even try to wrap it.

Fixes #508
