### PR TITLE
Fix for error in Firefox because of workaround for Safari

### DIFF
--- a/src/wrappers.js
+++ b/src/wrappers.js
@@ -179,12 +179,8 @@ window.ShadowDOMPolyfill = {};
   // shape of the descriptor and make all properties read-write.
   // https://bugs.webkit.org/show_bug.cgi?id=49739
   var isBrokenSafari = function() {
-    // Whether this is Safari 8 or not
-    if (!/AppleWebKit.*Version\/8\.0.*Safari/i.test(navigator.userAgent)) {
-      return false;
-    }
     var descr = Object.getOwnPropertyDescriptor(Node.prototype, 'nodeType');
-    return !!descr && 'set' in descr;
+    return descr && !descr.get && !descr.set;
   }();
 
   function installProperty(source, target, allowMethod, opt_blacklist) {

--- a/src/wrappers.js
+++ b/src/wrappers.js
@@ -179,6 +179,10 @@ window.ShadowDOMPolyfill = {};
   // shape of the descriptor and make all properties read-write.
   // https://bugs.webkit.org/show_bug.cgi?id=49739
   var isBrokenSafari = function() {
+    // Whether this is Safari 8 or not
+    if (!/AppleWebKit.*Version\/8\.0.*Safari/i.test(navigator.userAgent)) {
+      return false;
+    }
     var descr = Object.getOwnPropertyDescriptor(Node.prototype, 'nodeType');
     return !!descr && 'set' in descr;
   }();


### PR DESCRIPTION
Fix for https://github.com/Polymer/platform/issues/94
RegExp based on user agent examples from http://myip.ms/view/comp_browsers/3458/Safari_8.html beause I do not have any available machine with Safari 8
