### PR TITLE
Fix textContent setter

### DIFF
--- a/src/wrappers/Node.js
+++ b/src/wrappers/Node.js
@@ -628,6 +628,7 @@
       return s;
     },
     set textContent(textContent) {
+      if (textContent == null) textContent = '';
       var removedNodes = snapshotNodeList(this.childNodes);
 
       if (this.invalidateShadowRenderer()) {

--- a/test/js/Node.js
+++ b/test/js/Node.js
@@ -348,6 +348,13 @@ suite('Node', function() {
     assert.equal(div.textContent, 'abef');
   });
 
+  test('null textContent', function() {
+    var div = document.createElement('div');
+    var root = div.createShadowRoot();
+    div.textContent = null;
+    assert.equal(div.textContent, '');
+  });
+
   test('normalize', function() {
     var div = document.createElement('div');
     div.appendChild(document.createTextNode('foo\n'));


### PR DESCRIPTION
Previously doing myElement.textContent = null would result in a textContent == 'null'. It looks like the standard behavior for this should be to treat null, undefined, and empty string all as empty string.
